### PR TITLE
Update setup-windows.bat

### DIFF
--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -14,7 +14,7 @@ pause
 echo:
 echo [1/4] Checking Python...
 py -3.12 --version >nul 2>&1
-if %errorlevel% neq 0 (
+if errorlevel 1 (
     echo ERROR: Python 3.12 not found!
     echo:
     echo HiDock requires Python 3.12 for optimal compatibility.
@@ -63,7 +63,7 @@ cd ..
 echo:
 echo [3/4] Checking Node.js for Web Apps...
 node --version >nul 2>&1
-if %errorlevel% neq 0 (
+if errorlevel 1 (
     echo Node.js not found - skipping web apps setup
     echo:
     echo OPTIONAL: Install Node.js for Web Apps
@@ -80,7 +80,7 @@ if %errorlevel% neq 0 (
     echo Setting up HiDock Web App...
     cd hidock-web-app
     call npm install
-    if %errorlevel% neq 0 (
+    if errorlevel 1 (
         echo WARNING: Web app setup failed
     ) else (
         echo Web app setup complete!
@@ -124,3 +124,4 @@ echo:
 echo Enjoy using HiDock! 🎵
 echo:
 pause
+


### PR DESCRIPTION
Use if errorlevel N instead of if %errorlevel% inside scripts that check right after a command.

# Pull Request

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Changes Made

- Change %errorlevel% to errorlevel
%errorlevel% is expanded when the batch file is parsed, not after each command. This means console returns:
================================
  HiDock Next - Quick Setup
================================

This will set up HiDock apps for immediate use.

Press any key to continue . . .

[1/4] Checking Python...

Press any key to continue . . .

Then exits.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
