### PR TITLE
Enable MP3-first downloads, chunked Whisper uploads, richer transcription UX, and MACOS optimizations

### DIFF
--- a/apps/desktop/config/pyproject.toml
+++ b/apps/desktop/config/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "customtkinter",
     "Pillow",
     "pygame",
+    "openai>=1.0.0",
     "google-generativeai",
     "matplotlib",
     "numpy",

--- a/apps/desktop/config/requirements.txt
+++ b/apps/desktop/config/requirements.txt
@@ -9,6 +9,7 @@ pyusb
 customtkinter
 Pillow
 pygame
+openai>=1.0.0
 google-generativeai
 matplotlib
 numpy

--- a/apps/desktop/src/audio_metadata_mixin.py
+++ b/apps/desktop/src/audio_metadata_mixin.py
@@ -306,9 +306,16 @@ class AudioMetadataMixin:
             # Check common download locations
             import os
             download_dir = getattr(self, 'download_directory', os.path.expanduser("~/Downloads"))
-            potential_path = os.path.join(download_dir, filename)
-            if os.path.exists(potential_path):
-                return potential_path
+            safe_filename = filename.replace(":", "-").replace(" ", "_").replace("\\", "_").replace("/", "_")
+            mp3_path = os.path.join(download_dir, "mp3", safe_filename.replace(".hda", ".mp3"))
+            if os.path.exists(mp3_path):
+                return mp3_path
+            hda_path = os.path.join(download_dir, "hda", safe_filename)
+            if os.path.exists(hda_path):
+                return hda_path
+            legacy_path = os.path.join(download_dir, safe_filename)
+            if os.path.exists(legacy_path):
+                return legacy_path
             
             return None
             

--- a/apps/desktop/src/gui_actions_file.py
+++ b/apps/desktop/src/gui_actions_file.py
@@ -32,7 +32,14 @@ class FileActionsMixin:
             str: A safe local file path.
         """
         safe_filename = device_filename.replace(":", "-").replace(" ", "_").replace("\\", "_").replace("/", "_")
-        return os.path.join(self.download_directory, safe_filename)
+        mp3_path = os.path.join(self.download_directory, "mp3", os.path.splitext(safe_filename)[0] + ".mp3")
+        if os.path.exists(mp3_path):
+            return mp3_path
+        hda_path = os.path.join(self.download_directory, "hda", safe_filename)
+        if os.path.exists(hda_path):
+            return hda_path
+        legacy_path = os.path.join(self.download_directory, safe_filename)
+        return legacy_path
 
     def download_selected_files_gui(self):
         """Handles the download of selected files in the GUI by setting up a queue."""

--- a/apps/desktop/src/gui_event_handlers.py
+++ b/apps/desktop/src/gui_event_handlers.py
@@ -108,8 +108,10 @@ class EventHandlersMixin:
 
             # Update file operations manager with new download directory
             if hasattr(self, "file_operations_manager"):
-                self.file_operations_manager.download_dir = Path(new_dir)
-                self.file_operations_manager.download_dir.mkdir(parents=True, exist_ok=True)
+                self.file_operations_manager.set_download_directory(new_dir)
+
+            if hasattr(self, "offline_mode_manager"):
+                self.offline_mode_manager.download_directory = new_dir
 
             # Refresh file status to reflect availability in new directory
             if hasattr(self, "refresh_file_status_after_directory_change"):

--- a/apps/desktop/src/offline_mode_manager.py
+++ b/apps/desktop/src/offline_mode_manager.py
@@ -71,22 +71,30 @@ class OfflineModeManager:
         """Get the local file path for offline playback."""
         # First check cached metadata
         cached_metadata = self.file_operations_manager.metadata_cache.get_metadata(filename)
-        if cached_metadata and cached_metadata.local_path and os.path.exists(cached_metadata.local_path):
-            return cached_metadata.local_path
+        if cached_metadata:
+            candidate_paths = [
+                getattr(cached_metadata, "local_path_mp3", None),
+                cached_metadata.local_path,
+            ]
+            for candidate in candidate_paths:
+                if candidate and os.path.exists(candidate):
+                    return candidate
         
         # If not found in cache, check download directory directly
         # Use the same filename sanitization as _get_local_filepath
         safe_filename = filename.replace(":", "-").replace(" ", "_").replace("\\", "_").replace("/", "_")
         
-        # Check for .wav file (converted from .hda)
-        wav_path = os.path.join(self.download_directory, safe_filename.replace(".hda", ".wav"))
-        if os.path.exists(wav_path):
-            return wav_path
-            
-        # Check for original .hda file
-        hda_path = os.path.join(self.download_directory, safe_filename)
+        mp3_path = os.path.join(self.download_directory, "mp3", safe_filename.replace(".hda", ".mp3"))
+        if os.path.exists(mp3_path):
+            return mp3_path
+
+        hda_path = os.path.join(self.download_directory, "hda", safe_filename)
         if os.path.exists(hda_path):
             return hda_path
+
+        legacy_path = os.path.join(self.download_directory, safe_filename)
+        if os.path.exists(legacy_path):
+            return legacy_path
             
         return None
 

--- a/run-desktop.sh
+++ b/run-desktop.sh
@@ -1,4 +1,11 @@
-#!/bin/bash
+#!/bin/zsh
 # Convenience launcher for HiDock Desktop App
+
+emulate -L zsh
+setopt errexit pipefail
+
+SCRIPT_DIR=${0:A:h}
+cd "$SCRIPT_DIR"
+
 echo "Launching HiDock Desktop App..."
-./scripts/run/run-hidock-desktop.sh
+"$SCRIPT_DIR/scripts/run/run-hidock-desktop.sh"

--- a/scripts/run/run-hidock-desktop.sh
+++ b/scripts/run/run-hidock-desktop.sh
@@ -1,22 +1,40 @@
-#!/bin/bash
+#!/bin/zsh
+
+emulate -L zsh
+setopt errexit pipefail
+
 echo "Starting HiDock Desktop Application..."
 echo
 
 # Navigate to project root (two levels up from scripts/run)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/../.."
+SCRIPT_PATH=${0:A}
+SCRIPT_DIR=${SCRIPT_PATH:h}
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+cd "$ROOT_DIR"
 
 # Check if we're in the correct directory
 if [ ! -d "apps/desktop" ]; then
     echo "Error: apps/desktop directory not found!"
     echo "Make sure the hidock-next project structure is intact."
     echo "Current directory: $(pwd)"
-    read -p "Press Enter to continue..."
+    read -r "?Press Enter to continue..."
     exit 1
 fi
 
 # Navigate to desktop app directory
 cd apps/desktop
+
+CONFIG_FILE="config/hidock_config.json"
+CONFIG_TEMPLATE="config/hidock_config.json.example"
+
+if [ ! -f "$CONFIG_FILE" ] && [ -f "$CONFIG_TEMPLATE" ]; then
+    echo "Creating default HiDock config from template..."
+    cp "$CONFIG_TEMPLATE" "$CONFIG_FILE"
+fi
+
+# Ensure log directory and file exist to avoid runtime errors
+mkdir -p logs
+touch logs/test_hidock.log
 
 # Check if virtual environment exists
 if [ ! -d ".venv" ]; then
@@ -25,7 +43,7 @@ if [ ! -d ".venv" ]; then
     echo "  python3 setup.py"
     echo "or"
     echo "  ./setup-unix.sh"
-    read -p "Press Enter to continue..."
+    read -r "?Press Enter to continue..."
     exit 1
 fi
 
@@ -42,14 +60,14 @@ else
     echo "Virtual environment appears corrupted."
     echo "Please run setup again:"
     echo "  python3 setup.py"
-    read -p "Press Enter to continue..."
+    read -r "?Press Enter to continue..."
     exit 1
 fi
 
 echo "Checking if main.py exists..."
 if [ ! -f "main.py" ]; then
     echo "Error: main.py not found in apps/desktop directory!"
-    read -p "Press Enter to continue..."
+    read -r "?Press Enter to continue..."
     exit 1
 fi
 
@@ -65,6 +83,13 @@ echo
 # Set UTF-8 encoding to handle emoji characters
 export PYTHONIOENCODING=utf-8
 
+# Silence deprecated pkg_resources warning triggered by pygame
+if [[ -z ${PYTHONWARNINGS-} ]]; then
+    export PYTHONWARNINGS="ignore::UserWarning:pkg_resources"
+else
+    export PYTHONWARNINGS="$PYTHONWARNINGS,ignore::UserWarning:pkg_resources"
+fi
+
 # Use the appropriate Python executable
 if [ -n "$PYTHON_EXE" ]; then
     "$PYTHON_EXE" main.py
@@ -77,7 +102,7 @@ else
     else
         echo "Error: Python not found!"
         echo "Please ensure Python is installed and in your PATH."
-        read -p "Press Enter to continue..."
+        read -r "?Press Enter to continue..."
         exit 1
     fi
 fi
@@ -86,5 +111,5 @@ fi
 if [ $? -ne 0 ]; then
     echo
     echo "Application exited with an error."
-    read -p "Press Enter to continue..."
+    read -r "?Press Enter to continue..."
 fi


### PR DESCRIPTION
* Split the download cache into audio/hda + audio/mp3, auto-migrate legacy files, generate MP3s right after each .hda download, and track them in metadata (local_path_mp3 + schema migration).
* Prefer the MP3 assets everywhere (playback, offline mode, transcription), reuse cached audio for chunked OpenAI uploads, and stream status updates with resilient diff-highlighting in the GUI.
* Modernize the macOS launch/setup scripts (setup-unix.sh, run-desktop.sh, scripts/run/run-hidock-desktop.sh) for native /bin/zsh, absolute pathing, log/config bootstrapping, and pygame warning suppression.

##Testing
* Manual: launched desktop app, downloaded recordings (MP3 + HDA generated, metadata updated), ran OpenAI transcription with chunk progress, cancelled jobs (partials cleaned up), replayed downloads to confirm MP3 preference.
* Automated: not run (no existing test suite).