### PR TITLE
Add support for HiDock P1 Mini with VID 0x3887

### DIFF
--- a/apps/desktop/src/constants.py
+++ b/apps/desktop/src/constants.py
@@ -12,7 +12,9 @@ ease of modification.
 # constants.py
 
 # --- USB Device Constants ---
-DEFAULT_VENDOR_ID = 0x10D6  # Actions Semiconductor
+DEFAULT_VENDOR_ID = 0x10D6  # Actions Semiconductor (older devices)
+ALTERNATE_VENDOR_ID = 0x3887  # HiDock (newer P1 Mini devices)
+ALL_VENDOR_IDS = [DEFAULT_VENDOR_ID, ALTERNATE_VENDOR_ID]
 
 # All known HiDock device PIDs (no hierarchy - all devices are equal)
 # Source: Official HiDock HiNotes jensen.js (December 2025)

--- a/apps/desktop/src/device_interface.py
+++ b/apps/desktop/src/device_interface.py
@@ -662,10 +662,17 @@ def detect_device_model(vendor_id: int, product_id: int) -> DeviceModel:
     """
     model_map = {
         0xAF0C: DeviceModel.H1,
+        0x0100: DeviceModel.H1,  # H1 alt
+        0x0102: DeviceModel.H1,  # H1 alt
         0xAF0D: DeviceModel.H1E,
         0xB00D: DeviceModel.H1E,  # H1E device
+        0x0101: DeviceModel.H1E,  # H1E alt
+        0x0103: DeviceModel.H1E,  # H1E alt
         0xAF0E: DeviceModel.P1,
         0xB00E: DeviceModel.P1,  # P1 device (newer PID)
+        0x2040: DeviceModel.P1,  # P1 alt
+        0xAF0F: DeviceModel.P1,  # P1 Mini
+        0x2041: DeviceModel.P1,  # P1 Mini (newer devices with VID 0x3887)
     }
 
     return model_map.get(product_id, DeviceModel.UNKNOWN)


### PR DESCRIPTION
## Summary
- Add support for newer HiDock P1 Mini devices that use Vendor ID `0x3887` instead of the original Actions Semiconductor VID (`0x10D6`)
- Update device discovery to scan all known vendor IDs
- Add missing product IDs to model detection

## Changes
- `constants.py`: Add `ALTERNATE_VENDOR_ID` (0x3887) and `ALL_VENDOR_IDS` list
- `desktop_device_adapter.py`: Update `discover_devices()` to iterate over all vendor IDs
- `device_interface.py`: Add all product ID variants to `detect_device_model()` mapping

## Test plan
- [x] Tested with HiDock P1 Mini (VID: 0x3887, PID: 0x2041, SN: HDPM253807307)
- [x] Device successfully discovered and connected
- [x] File list retrieved (23 files)
- [x] Device info parsed correctly (firmware v2.1.1)