### PR TITLE
fix(scripts): restore missing scripts/env/select_venv.py (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .venv/
 venv/
 ENV/
+!scripts/env/
 apps/desktop/.venv/
 apps/web/node_modules/
 apps/audio-insights/node_modules/

--- a/scripts/env/select_venv.py
+++ b/scripts/env/select_venv.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Resolve / create the per-platform virtual environment for hidock-next.
+Restores the missing scripts/env/select_venv.py that setup-windows.bat and
+setup-unix.sh expect (issue #41).
+
+Contract:
+  --print           Print the absolute venv path if it exists; otherwise no output.
+  --ensure          Create the venv at the platform-appropriate path if missing.
+  --ensure --print  Create (if missing) and print the absolute path.
+"""
+
+import argparse
+import os
+import sys
+import venv
+from pathlib import Path
+
+
+def venv_dir_name() -> str:
+    if sys.platform.startswith("win"):
+        return ".venv.win"
+    if sys.platform == "darwin":
+        return ".venv.mac"
+    return ".venv.nix"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def venv_path() -> Path:
+    return repo_root() / venv_dir_name()
+
+
+def venv_python(path: Path) -> Path:
+    if sys.platform.startswith("win"):
+        return path / "Scripts" / "python.exe"
+    return path / "bin" / "python"
+
+
+def ensure(path: Path) -> None:
+    if venv_python(path).exists():
+        return
+    path.mkdir(parents=True, exist_ok=True)
+    builder = venv.EnvBuilder(with_pip=True, clear=False, upgrade=False, symlinks=(os.name != "nt"))
+    builder.create(str(path))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ensure", action="store_true")
+    parser.add_argument("--print", dest="do_print", action="store_true")
+    args = parser.parse_args()
+
+    path = venv_path()
+
+    if args.ensure:
+        try:
+            ensure(path)
+        except Exception as exc:
+            print(f"ERROR: failed to create venv at {path}: {exc}", file=sys.stderr)
+            return 1
+
+    if args.do_print and venv_python(path).exists():
+        print(str(path))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Restores the missing `scripts/env/select_venv.py` referenced by `setup-windows.bat` and `setup-unix.sh`. Without it, fresh-clone setup fails in step 2/4 with `No such file or directory` and cannot create the venv. Fixes #41.
- Adds a `!scripts/env/` negation to `.gitignore` so the new source directory is not masked by the existing `ENV/` venv-ignore pattern on case-insensitive filesystems (Windows, default macOS).

## Behavior
Contract inferred from how `setup-windows.bat` calls the script:
- `--print` — resolve the platform-appropriate venv path (`.venv.win` / `.venv.mac` / `.venv.nix` at repo root) and print it if it exists.
- `--ensure` — create the venv at that path if missing.
- `--ensure --print` — do both.

Implementation uses the stdlib `venv` module (`with_pip=True`), no third-party deps. Symlinks are enabled on non-Windows platforms.

## Test plan
- [x] On a fresh Windows clone with Python 3.12: `py -3.12 scripts\env\select_venv.py --ensure --print` creates `.venv.win` and prints its absolute path.
- [x] Re-running with `--print` only (after creation) prints the path without recreating.
- [x] `setup-windows.bat`'s desktop-app install path (`pip install -e "apps/desktop[dev]"`) completes successfully into that venv.
- [ ] macOS / Linux smoke test from a maintainer with `setup-unix.sh` (path logic is symmetric but I haven't run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated version control exclusions to ignore environment configuration files.
  * Added automated virtual environment management to support cross-platform development setup with platform-specific Python configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sgeraldes/hidock-next/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->