### PR TITLE
fix(desktop): Shift+click range selection in the file list

### DIFF
--- a/apps/desktop/src/gui_event_handlers.py
+++ b/apps/desktop/src/gui_event_handlers.py
@@ -135,7 +135,7 @@ class EventHandlersMixin:
         )
         return new_dir
 
-    def _on_file_button1_press(self, event):  # Identical to original logic
+    def _on_file_button1_press(self, event):
         """
         Handles the Button-1 press event on the file Treeview.
 

--- a/apps/desktop/src/gui_event_handlers.py
+++ b/apps/desktop/src/gui_event_handlers.py
@@ -182,27 +182,41 @@ class EventHandlersMixin:
             )
         ctrl_pressed = (event.state & 0x0004) != 0
         shift_pressed = (event.state & 0x0001) != 0
-        if shift_pressed:
-            logger.debug(
-                "GUI",
-                "_on_file_button1_press",
-                f"Shift+Click on item: {item_iid}. Allowing default range selection.",
-            )
-            return
+
+        # Shift+Click: select the contiguous range from the anchor (last plainly
+        # clicked row) to the clicked row. Implemented manually because this widget
+        # manages its own selection, so Tk's native anchor is unreliable.
+        anchor = getattr(self, "_selection_anchor_iid", None)
+        if shift_pressed and anchor:
+            all_children = self.file_tree.get_children("")
+            try:
+                a_idx = all_children.index(anchor)
+                b_idx = all_children.index(item_iid)
+                lo, hi = min(a_idx, b_idx), max(a_idx, b_idx)
+                self.file_tree.selection_set(all_children[lo : hi + 1])
+                logger.debug(
+                    "GUI",
+                    "_on_file_button1_press",
+                    f"Shift+Click range select: {anchor} -> {item_iid} ({hi - lo + 1} items).",
+                )
+                return "break"
+            except ValueError:
+                # Anchor or target no longer in the tree; fall through to toggle.
+                pass
+
+        # No Shift (plain click, or Ctrl/Cmd): toggle this row, and make it the new
+        # anchor so a following Shift+Click extends from here.
         if is_currently_selected_before_toggle:
             self.file_tree.selection_remove(item_iid)
-            logger.debug(
-                "GUI",
-                "_on_file_button1_press",
-                f"Toggled OFF item: {item_iid} (Modifier: {'Ctrl' if ctrl_pressed else 'None'})",
-            )
         else:
             self.file_tree.selection_add(item_iid)
-            logger.debug(
-                "GUI",
-                "_on_file_button1_press",
-                f"Toggled ON item: {item_iid} (Modifier: {'Ctrl' if ctrl_pressed else 'None'})",
-            )
+        self._selection_anchor_iid = item_iid
+        logger.debug(
+            "GUI",
+            "_on_file_button1_press",
+            f"Toggled {'OFF' if is_currently_selected_before_toggle else 'ON'} item: {item_iid} "
+            f"(Modifier: {'Ctrl' if ctrl_pressed else 'None'}); anchor set.",
+        )
         return "break"
 
     def _on_transcription_column_click(self, file_iid: str):

--- a/apps/desktop/src/gui_main_window.py
+++ b/apps/desktop/src/gui_main_window.py
@@ -652,8 +652,8 @@ class HiDockToolGUI(
         self.visualizer_pinned_var = ctk.BooleanVar(value=get_conf("visualizer_pinned", False))
         self.visualizer_pinned = self.visualizer_pinned_var.get()  # Initialize from config
 
-        # Selection mode (default to single selection)
-        self.single_selection_mode_var = ctk.BooleanVar(value=get_conf("single_selection_mode", True))
+        # Selection mode (default to multi selection — enables batch download/delete)
+        self.single_selection_mode_var = ctk.BooleanVar(value=get_conf("single_selection_mode", False))
 
         # Calendar performance settings
         self.calendar_chunking_period_var = ctk.StringVar(value=get_conf("calendar_chunking_period", "1 Week"))


### PR DESCRIPTION
## Description
Fixes Shift+click in the desktop file list. Previously, holding Shift collapsed the selection to
a single row instead of selecting a range, making it tedious to pick a block of recordings for
batch download/delete.

**Root cause:** the Treeview manages its own selection in `_on_file_button1_press`, but the Shift
branch deferred to Tk's *native* range select — which never works here because the native
selection anchor is never set. Fix: track the last-clicked row as an anchor and, on Shift+click,
`selection_set` the slice of `get_children("")` between anchor and clicked row. Click-to-toggle
behavior is unchanged.

Also (optional, separate commit): default `single_selection_mode` to `False` so multi-select and
the existing batch actions aren't hidden behind a setting. Drop this commit if single is the
preferred default.

## Type of Change
- [x] Bug fix (Shift+click range selection)
- [x] New feature / preference (optional default-to-multi commit)
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Manual testing on macOS (Apple Silicon, Python 3.12): click-to-toggle, Shift+click range
  (both directions), and Ctrl/Cmd+click all behave correctly.
- [x] `tests/test_gui_event_handlers.py` passes (run via `PYTHONPATH=src pytest
  tests/test_gui_event_handlers.py --no-cov`).
- [ ] Not yet verified on Windows/Linux. The change should be platform-neutral — the Shift bit
  (`0x0001`) is consistent across Tk platforms, the range uses the tree's own row order (not Tk's
  native anchor), and all non-Shift clicks toggle (so it doesn't depend on distinguishing Ctrl
  from Cmd). A Windows sanity check before merge would be welcome.

> Note: the full desktop suite (`pytest apps/desktop/tests`) does not currently collect on
> `main` — unrelated to this change. Many tests import a `tests.helpers` package that isn't in
> the repo, and there's no `pythonpath`/src-on-path config, so imports like `config_and_logger`
> fail at collection. Happy to open a separate issue/PR for the test harness if useful.

## Checklist
- [x] Code follows style guidelines (120-char lines, conventional commits)
- [x] Self-review completed
- [x] Scoped to the file-list selection change (`gui_event_handlers.py`; optional
  `gui_main_window.py`)
- [ ] Documentation update — n/a

## Files
- `apps/desktop/src/gui_event_handlers.py` — Shift+click range selection fix
- `apps/desktop/src/gui_main_window.py` — *(optional commit)* default to multi-selection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File lists now support more reliable multi-selection, including Shift+Click contiguous range selection between items.
  * The app now starts in multi-selection mode by default, so selecting multiple files is easier from the start.

* **Bug Fixes**
  * Improved selection behavior for Shift+Click edge cases (for example, when the range anchor can’t be determined), with selection toggling updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->