### PR TITLE
fix(electron): database initialization crashes on first boot (fresh machine, no existing DB)

### DIFF
--- a/apps/electron/electron/main/services/database.ts
+++ b/apps/electron/electron/main/services/database.ts
@@ -1386,9 +1386,13 @@ export async function initializeDatabase(): Promise<void> {
     // --- PHASE 1: CORE TABLES ---
     console.log('[Database] Phase 1: Ensuring core tables exist...')
     for (const sql of statements) {
-      if (sql.toUpperCase().startsWith('CREATE TABLE')) {
+      // Statements split from SCHEMA may carry leading "-- comment" lines; strip them
+      // before detection, otherwise commented CREATE TABLEs are skipped on a fresh DB
+      // and Phase 2's PRAGMA table_info() lookups crash on the missing tables.
+      const executable = sql.replace(/^(\s*--[^\n]*\n?)+/, '').trim()
+      if (executable.toUpperCase().startsWith('CREATE TABLE')) {
         try {
-          database.run(sql)
+          database.run(executable)
         } catch (e) {
           console.warn(`[Database] Table creation warning: ${(e as Error).message}`)
         }
@@ -1399,42 +1403,47 @@ export async function initializeDatabase(): Promise<void> {
     // This runs on EVERY boot to ensure parity between code and disk.
     console.log('[Database] Phase 2: Aligning table structures...')
     
-    // Repair Recordings
+    // Repair Recordings (guarded like transcription_queue below: PRAGMA returns [] when
+    // the table is missing, e.g. first boot on a fresh machine — Phase 4 creates it later)
     const recordingsInfo = database.exec("PRAGMA table_info(recordings)")
-    const recCols = recordingsInfo[0].values.map(col => col[1])
-    const recordingRepairs = [
-      { name: 'migrated_to_capture_id', def: "TEXT" },
-      { name: 'migration_status', def: "TEXT CHECK(migration_status IN ('pending', 'migrated', 'skipped', 'error')) DEFAULT 'pending'" },
-      { name: 'migrated_at', def: "TEXT" }
-    ]
-    for (const col of recordingRepairs) {
-      if (!recCols.includes(col.name)) {
-        console.log(`[Database] Repairing recordings: adding ${col.name}`)
-        try { database.run(`ALTER TABLE recordings ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+    if (recordingsInfo.length > 0 && recordingsInfo[0].values) {
+      const recCols = recordingsInfo[0].values.map(col => col[1])
+      const recordingRepairs = [
+        { name: 'migrated_to_capture_id', def: "TEXT" },
+        { name: 'migration_status', def: "TEXT CHECK(migration_status IN ('pending', 'migrated', 'skipped', 'error')) DEFAULT 'pending'" },
+        { name: 'migrated_at', def: "TEXT" }
+      ]
+      for (const col of recordingRepairs) {
+        if (!recCols.includes(col.name)) {
+          console.log(`[Database] Repairing recordings: adding ${col.name}`)
+          try { database.run(`ALTER TABLE recordings ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+        }
       }
     }
 
-    // Repair Knowledge Captures
+    // Repair Knowledge Captures (same missing-table guard as above)
     const captureInfo = database.exec("PRAGMA table_info(knowledge_captures)")
-    const capCols = captureInfo[0].values.map(col => col[1])
-    const knowledgeRepairs = [
-      { name: 'category', def: "category TEXT CHECK(category IN ('meeting', 'interview', '1:1', 'brainstorm', 'note', 'other')) DEFAULT 'meeting'" },
-      { name: 'status', def: "status TEXT CHECK(status IN ('processing', 'ready', 'enriched')) DEFAULT 'ready'" },
-      { name: 'quality_rating', def: "quality_rating TEXT CHECK(quality_rating IN ('valuable', 'archived', 'low-value', 'garbage', 'unrated')) DEFAULT 'unrated'" },
-      { name: 'quality_confidence', def: "quality_confidence REAL" },
-      { name: 'quality_assessed_at', def: "quality_assessed_at TEXT" },
-      { name: 'storage_tier', def: "storage_tier TEXT CHECK(storage_tier IN ('hot', 'cold', 'expiring', 'deleted')) DEFAULT 'hot'" },
-      { name: 'retention_days', def: "retention_days INTEGER" },
-      { name: 'expires_at', def: "expires_at TEXT" },
-      { name: 'meeting_id', def: "meeting_id TEXT REFERENCES meetings(id)" },
-      { name: 'correlation_confidence', def: "correlation_confidence REAL" },
-      { name: 'correlation_method', def: "correlation_method TEXT" },
-      { name: 'source_recording_id', def: "source_recording_id TEXT REFERENCES recordings(id)" }
-    ]
-    for (const col of knowledgeRepairs) {
-      if (!capCols.includes(col.name)) {
-        console.log(`[Database] Repairing knowledge_captures: adding ${col.name}`)
-        try { database.run(`ALTER TABLE knowledge_captures ADD COLUMN ${col.def}`) } catch (e) {}
+    if (captureInfo.length > 0 && captureInfo[0].values) {
+      const capCols = captureInfo[0].values.map(col => col[1])
+      const knowledgeRepairs = [
+        { name: 'category', def: "category TEXT CHECK(category IN ('meeting', 'interview', '1:1', 'brainstorm', 'note', 'other')) DEFAULT 'meeting'" },
+        { name: 'status', def: "status TEXT CHECK(status IN ('processing', 'ready', 'enriched')) DEFAULT 'ready'" },
+        { name: 'quality_rating', def: "quality_rating TEXT CHECK(quality_rating IN ('valuable', 'archived', 'low-value', 'garbage', 'unrated')) DEFAULT 'unrated'" },
+        { name: 'quality_confidence', def: "quality_confidence REAL" },
+        { name: 'quality_assessed_at', def: "quality_assessed_at TEXT" },
+        { name: 'storage_tier', def: "storage_tier TEXT CHECK(storage_tier IN ('hot', 'cold', 'expiring', 'deleted')) DEFAULT 'hot'" },
+        { name: 'retention_days', def: "retention_days INTEGER" },
+        { name: 'expires_at', def: "expires_at TEXT" },
+        { name: 'meeting_id', def: "meeting_id TEXT REFERENCES meetings(id)" },
+        { name: 'correlation_confidence', def: "correlation_confidence REAL" },
+        { name: 'correlation_method', def: "correlation_method TEXT" },
+        { name: 'source_recording_id', def: "source_recording_id TEXT REFERENCES recordings(id)" }
+      ]
+      for (const col of knowledgeRepairs) {
+        if (!capCols.includes(col.name)) {
+          console.log(`[Database] Repairing knowledge_captures: adding ${col.name}`)
+          try { database.run(`ALTER TABLE knowledge_captures ADD COLUMN ${col.def}`) } catch (e) {}
+        }
       }
     }
 


### PR DESCRIPTION
# Pull Request

## Description

On a machine that has never run the Electron app (no existing SQLite file), initialization crashes and the splash screen hangs on "Initializing database..." forever:

```
[Database] FATAL initialization error: TypeError: Cannot read properties of undefined (reading 'values')
    at initializeDatabase (out/main/index.js:...)
```

**Root cause — two compounding bugs in `initializeDatabase` (`electron/main/services/database.ts`):**

1. **Phase 1 never creates most tables on a fresh DB.** `SCHEMA.split(';')` keeps leading `-- comment` lines attached to the following statement, so `sql.toUpperCase().startsWith('CREATE TABLE')` is false for every table whose CREATE statement has a comment above it (most of them). On an existing DB this is invisible; on a fresh DB the core tables simply don't get created.
2. **Phase 2 dereferences PRAGMA results without a guard.** `database.exec("PRAGMA table_info(recordings)")` returns `[]` when the table doesn't exist, so `recordingsInfo[0].values` throws. The same code already guards `transcription_queue` and `chat_messages` — `recordings` and `knowledge_captures` were missing that guard.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Related Issues

N/A (found while setting up the app on a second machine)

## Changes Made

- Phase 1: strip leading `--` comment lines before the CREATE TABLE detection (and run the stripped statement), so core tables are actually created on a fresh DB
- Phase 2: apply the existing missing-table guard pattern (`info.length > 0 && info[0].values`) to `recordings` and `knowledge_captures`

## Testing

- [x] Manual testing completed

Reproduced on a Windows machine with no prior DB: before the fix, FATAL TypeError at Phase 2 and the splash never advances; after the fix, initialization runs through all migrations to schema v24, integrity checks pass, and the app boots normally. Machines with an existing DB are unaffected (the guards are no-ops there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization reliability during first-time setup and partial recovery scenarios.
  * Prevented disabled or commented schema statements from being executed unexpectedly.
  * Avoided startup failures when expected database tables are not yet available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->