### PR TITLE
fix(knowledge-graph): keep the edge type in makeEdgeId slugs

### DIFF
--- a/packages/knowledge-graph/package-lock.json
+++ b/packages/knowledge-graph/package-lock.json
@@ -27,9 +27,9 @@
       "dev": true,
       "license": "MIT",
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
-        "@types/sql.js": "1.4.9",
-        "sql.js": "^1.11.0",
+        "better-sqlite3": "^12.11.1",
         "tsup": "^8.5.1",
         "typescript": "^5.6.0",
         "vitest": "^4"
@@ -38,7 +38,12 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "sql.js": "^1.11.0"
+        "better-sqlite3": ">=11"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {

--- a/packages/knowledge-graph/src/graph-store.ts
+++ b/packages/knowledge-graph/src/graph-store.ts
@@ -67,8 +67,14 @@ function makeNodeId(type: string, normKey: string): string {
   return `${type}:${slug}`
 }
 
+/**
+ * Deterministic edge id from the (source, target, type) triple. The triple is
+ * folded to lowercase before slugging so the UPPERCASE edge type survives the
+ * a-z character class — the type must stay distinguishable in the id, or every
+ * type between the same pair would collapse to one '_' and collide.
+ */
 function makeEdgeId(sourceId: string, targetId: string, type: string): string {
-  const combined = `${sourceId}|||${targetId}|||${type}`
+  const combined = `${sourceId}|||${targetId}|||${type}`.toLowerCase()
   const slug = combined.replace(/[^a-z0-9_|:]+/g, '_').slice(0, 120)
   return `edge:${slug}`
 }
@@ -179,12 +185,13 @@ export class KnowledgeGraphStore {
       return existing.id
     }
 
-    // New edge. The id is a lossy slug of (source, target, type): the 120-char
-    // truncation and uppercase types collapsing to '_' mean two DISTINCT triples
-    // can produce the same id. Same failure class as upsertNode above — the
-    // triple lookup misses, then the INSERT collides on the primary key
-    // ("UNIQUE constraint failed: graph_edges.id", which aborted transcript
-    // ingest forever). Detect a taken id and derive a stable, hashed variant.
+    // New edge. The id slug now preserves the edge type, but it is still lossy:
+    // the 120-char truncation (and case-folding of the node ids) means two
+    // DISTINCT triples can produce the same id. Same failure class as
+    // upsertNode above — the triple lookup misses, then the INSERT collides on
+    // the primary key ("UNIQUE constraint failed: graph_edges.id", which
+    // aborted transcript ingest forever). Detect a taken id and derive a
+    // stable, hashed variant.
     let edgeId = makeEdgeId(sourceId, targetId, type)
     const clash = this.db.queryOne<{ source_id: string; target_id: string; type: string }>(
       'SELECT source_id, target_id, type FROM graph_edges WHERE id = ?',

--- a/packages/knowledge-graph/tests/graph-store.test.ts
+++ b/packages/knowledge-graph/tests/graph-store.test.ts
@@ -179,18 +179,21 @@ describe('KnowledgeGraphStore', () => {
   })
 
   // --- Edge id collisions --------------------------------------------------
-  // makeEdgeId() is a lossy slug of (source, target, type): uppercase types
-  // collapse to '_' runs and the id truncates at 120 chars, so two DISTINCT
-  // triples can slug identically. Without clash handling this threw
-  // "UNIQUE constraint failed: graph_edges.id" and permanently aborted
-  // transcript ingest (14 transcripts stuck in production, each retried with
-  // a fresh LLM extraction every cycle).
+  // makeEdgeId() slugs the (source, target, type) triple. Historically the
+  // slug dropped uppercase edge types entirely (every type collapsed to '_'),
+  // and it still truncates at 120 chars, so two DISTINCT triples can slug
+  // identically. Without clash handling this threw "UNIQUE constraint failed:
+  // graph_edges.id" and permanently aborted transcript ingest (14 transcripts
+  // stuck in production, each retried with a fresh LLM extraction every
+  // cycle). The type is now folded to lowercase and kept in the slug; the
+  // hashed-variant fallback still covers truncation collisions.
 
   it('same (source,target) pair with different UPPERCASE types → two distinct edges', async () => {
     const { store, engine, dbPath } = await makeStore('edge-type-collide')
     paths.push(dbPath)
 
-    // 'ABOUT' and 'OWNS' both slugify to '_' — identical makeEdgeId output.
+    // 'ABOUT' and 'OWNS' used to slugify to the same '_' and collide; the type
+    // now survives in the slug, so the ids differ without the hash fallback.
     const meetingId = store.upsertNode({ type: 'meeting', label: 'Sync' })
     const topicId = store.upsertNode({ type: 'topic', label: 'Roadmap' })
     const e1 = store.upsertEdge({ sourceId: meetingId, targetId: topicId, type: 'ABOUT' })
@@ -198,6 +201,35 @@ describe('KnowledgeGraphStore', () => {
 
     expect(e1).not.toBe(e2)
     expect(engine.queryAll('SELECT id FROM graph_edges')).toHaveLength(2)
+  })
+
+  it('edge id encodes its type and does not depend on insertion order', async () => {
+    const { store, engine, dbPath } = await makeStore('edge-id-type-slug')
+    paths.push(dbPath)
+
+    const personId = store.upsertNode({ type: 'person', label: 'Hana' })
+    const meetingId = store.upsertNode({ type: 'meeting', label: 'Kickoff' })
+    const attended = store.upsertEdge({ sourceId: personId, targetId: meetingId, type: 'ATTENDED' })
+    const mentioned = store.upsertEdge({ sourceId: personId, targetId: meetingId, type: 'MENTIONED' })
+
+    // Both edges persist under ids that spell out their own type — not a bare
+    // '_' plus a hash suffix for whichever type happened to arrive second.
+    expect(attended).not.toBe(mentioned)
+    expect(attended).toContain('attended')
+    expect(mentioned).toContain('mentioned')
+    expect(engine.queryAll('SELECT id FROM graph_edges')).toHaveLength(2)
+
+    // Same triples ingested in the opposite order → the very same ids. Anything
+    // that keys on edge id (e.g. provenance rows) must not depend on which
+    // extraction happened to run first.
+    const reversed = await makeStore('edge-id-type-slug-reversed')
+    paths.push(reversed.dbPath)
+    const p2 = reversed.store.upsertNode({ type: 'person', label: 'Hana' })
+    const m2 = reversed.store.upsertNode({ type: 'meeting', label: 'Kickoff' })
+    const mentioned2 = reversed.store.upsertEdge({ sourceId: p2, targetId: m2, type: 'MENTIONED' })
+    const attended2 = reversed.store.upsertEdge({ sourceId: p2, targetId: m2, type: 'ATTENDED' })
+    expect(attended2).toBe(attended)
+    expect(mentioned2).toBe(mentioned)
   })
 
   it('triples differing only beyond the 120-char id truncation → two distinct edges', async () => {


### PR DESCRIPTION
## Problem

`makeEdgeId(sourceId, targetId, type)` slugs the combined triple with `replace(/[^a-z0-9_|:]+/g, '_')`. Node ids are lowercase, but edge types are UPPERCASE (`ATTENDED`, `MENTIONED`, ...), and the character class excludes A-Z — so the entire type collapsed to a single `_`. Every edge type between the same ordered node pair produced the same id (`edge:<src>|||<tgt>|||_`).

The clash-hash fallback added in the earlier edge-collision round (38e31614) prevents the crash, but the type was still not encoded in the id: whichever type was ingested first got the clean id and the other got a `__<hash>` variant. Edge ids were therefore **insertion-order dependent** — a type-ambiguous scheme that the upcoming F18 `graph_edge_sources.edge_id` provenance key would inherit. (Surfaced in the spec-004 design review, finding #13.)

## Fix

- Fold the `(source, target, type)` triple to lowercase before slugging, so the type survives the a-z class: ids are now distinct per type and deterministic regardless of ingest order (`edge:person:hana|||meeting:kickoff|||attended`).
- Updated the comments that described the old collapse behavior (upsertEdge clash note, test section header).
- New regression test: two types between the same pair get distinct, type-encoding ids, both rows persist, and re-ingesting in the opposite order yields the identical ids.

## Backward compatibility

Existing databases are unaffected: `upsertEdge` resolves edges by the `(source_id, target_id, type)` natural key first, so rows keep their stored ids — the new format only applies to newly created edges. No migration needed. The `__<shortHash>` fallback still covers the remaining lossy case (120-char truncation), verified by the existing truncation tests.

Also syncs `package-lock.json`'s `@hidock/database` entry, which was stale since the database package moved from sql.js to better-sqlite3 (any `npm install` in the package reproduces this).

## Gates

- `npx vitest run` in `packages/knowledge-graph`: **113/113 passed** (112 baseline + 1 new; the new test was watched failing before the fix)
- `npm run typecheck`: clean
- Edited test file additionally verified type-clean under strict ad-hoc tsc (the package tsconfig excludes `tests/` — pre-existing gap, tracked separately)