### PR TITLE
fix(calendar): honest deletion — local deletes become Move to Trash (spec-005/F17 T5 §D3b + AR3-4)

### DIFF
--- a/apps/electron/src/pages/Calendar.tsx
+++ b/apps/electron/src/pages/Calendar.tsx
@@ -653,19 +653,40 @@ export function Calendar() {
     }
   }, [refreshRecordings])
 
-  // Delete local recording (memoized)
+  // Move to Trash — soft delete (spec-005/F17 T5 §D3b, memoized). Routes through
+  // the cascade IPC that hides the recording (restorable) and pulls it from AI
+  // processing; nothing is erased from disk. The legacy recordings.delete IPC
+  // (permanent unlinkSync that keeps derived data) is intentionally NOT used —
+  // permanent deletion is Library's explicit "Delete permanently…" flow only.
+  // Confirm/toast copy mirrors Library's (deletionCopy.ts consolidation lands
+  // with the T5 branch).
   const handleDeleteLocal = useCallback(async (recording: UnifiedRecording) => {
     if (!hasLocalPath(recording)) return
 
-    const confirmed = window.confirm(`Delete "${recording.filename}" from local storage? This cannot be undone.`)
+    const confirmed = window.confirm(
+      `Move "${recording.filename}" to Trash? It will be hidden and excluded from all AI processing. ` +
+        'Nothing is erased — restore it from Trash, or delete it permanently later.'
+    )
     if (!confirmed) return
 
     setDeleting(recording.id)
     try {
-      await window.electronAPI.recordings.delete(recording.id)
+      const res = await window.electronAPI.recordings.deleteCascade(recording.id, false)
+      if (!res?.success) throw new Error(res?.error || 'Delete failed')
       await refreshRecordings(false)
+      toast.success('Moved to Trash', `"${recording.filename}" is hidden and excluded from processing.`, {
+        duration: 8000,
+        action: {
+          label: 'Undo',
+          onClick: async () => {
+            await window.electronAPI.recordings.restore(recording.id)
+            await refreshRecordings(false)
+          }
+        }
+      })
     } catch (e) {
       console.error('Delete failed:', e)
+      toast.error('Delete Failed', `Failed to move "${recording.filename}" to Trash. Please try again.`)
     } finally {
       setDeleting(null)
     }
@@ -969,21 +990,23 @@ export function Calendar() {
                             <Trash2 className="h-3 w-3" />
                           </Button>
                         )}
-                        {/* Delete - local-only: delete local file */}
-                        {recording.location === 'local-only' && (
+                        {/* Move to Trash — soft delete (spec-005/F17 T5 §D3b). AR3-4: the
+                            hasLocalPath gate keeps capture-only synthetic rows (localPath
+                            === '') from rendering any delete affordance. */}
+                        {recording.location === 'local-only' && hasLocalPath(recording) && (
                           <Button variant="ghost" size="icon" className="h-6 w-6 text-orange-500 hover:text-orange-600"
                             onClick={() => handleDeleteLocal(recording)}
                             disabled={deleting === recording.id}
-                            title="Delete local file">
+                            title="Move to Trash">
                             <Trash2 className="h-3 w-3" />
                           </Button>
                         )}
-                        {/* Delete - both: delete local copy only */}
+                        {/* Move to Trash for synced rows — device copy is untouched */}
                         {recording.location === 'both' && (
                           <Button variant="ghost" size="icon" className="h-6 w-6 text-muted-foreground hover:text-orange-500"
                             onClick={() => handleDeleteLocal(recording)}
                             disabled={deleting === recording.id}
-                            title="Delete local copy">
+                            title="Move to Trash">
                             <Trash2 className="h-3 w-3" />
                           </Button>
                         )}
@@ -1092,21 +1115,23 @@ export function Calendar() {
                             {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}
-                        {/* Delete local - only for local-only recordings */}
-                        {recording.location === 'local-only' && (
+                        {/* Move to Trash — soft delete (spec-005/F17 T5 §D3b). AR3-4: the
+                            hasLocalPath gate keeps capture-only synthetic rows (localPath
+                            === '') from rendering any delete affordance. */}
+                        {recording.location === 'local-only' && hasLocalPath(recording) && (
                           <Button variant="ghost" size="icon" className="h-6 w-6 text-orange-500 hover:text-orange-600"
                             onClick={(e) => { e.stopPropagation(); handleDeleteLocal(recording) }}
                             disabled={deleting === recording.id}
-                            title="Delete local file">
+                            title="Move to Trash">
                             <Trash2 className="h-3 w-3" />
                           </Button>
                         )}
-                        {/* Delete for synced recordings (both locations) - deletes local copy only */}
+                        {/* Move to Trash for synced rows — device copy is untouched */}
                         {recording.location === 'both' && (
                           <Button variant="ghost" size="icon" className="h-6 w-6 text-muted-foreground hover:text-orange-500"
                             onClick={(e) => { e.stopPropagation(); handleDeleteLocal(recording) }}
                             disabled={deleting === recording.id}
-                            title="Delete local copy (keeps on device)">
+                            title="Move to Trash">
                             {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}

--- a/apps/electron/src/pages/Calendar.tsx
+++ b/apps/electron/src/pages/Calendar.tsx
@@ -987,7 +987,7 @@ export function Calendar() {
                             onClick={() => handleDeleteFromDevice(recording)}
                             disabled={!deviceConnected || deleting === recording.id}
                             title="Delete from device">
-                            <Trash2 className="h-3 w-3" />
+                            {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}
                         {/* Move to Trash — soft delete (spec-005/F17 T5 §D3b). AR3-4: the
@@ -998,7 +998,7 @@ export function Calendar() {
                             onClick={() => handleDeleteLocal(recording)}
                             disabled={deleting === recording.id}
                             title="Move to Trash">
-                            <Trash2 className="h-3 w-3" />
+                            {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}
                         {/* Move to Trash for synced rows — device copy is untouched */}
@@ -1007,7 +1007,7 @@ export function Calendar() {
                             onClick={() => handleDeleteLocal(recording)}
                             disabled={deleting === recording.id}
                             title="Move to Trash">
-                            <Trash2 className="h-3 w-3" />
+                            {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}
                       </div>
@@ -1123,7 +1123,7 @@ export function Calendar() {
                             onClick={(e) => { e.stopPropagation(); handleDeleteLocal(recording) }}
                             disabled={deleting === recording.id}
                             title="Move to Trash">
-                            <Trash2 className="h-3 w-3" />
+                            {deleting === recording.id ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
                           </Button>
                         )}
                         {/* Move to Trash for synced rows — device copy is untouched */}

--- a/apps/electron/src/pages/__tests__/Calendar.test.tsx
+++ b/apps/electron/src/pages/__tests__/Calendar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { getWeekDates } from '@/lib/calendar-utils'
 
@@ -25,6 +25,8 @@ vi.mock('@/components/RecordingLinkDialog', () => ({ RecordingLinkDialog: () => 
 vi.mock('@/components/ui/toaster', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 let meetingsFixture: any[] = []
+// Mutable so individual tests can flip UI config (e.g. showListView) before render.
+let configFixture: Record<string, any> = {}
 
 const appActions = {
   navigateWeek: vi.fn(),
@@ -52,7 +54,7 @@ vi.mock('@/store/useAppStore', () => ({
 
 vi.mock('@/store/domain/useConfigStore', () => ({
   useConfigStore: vi.fn((selector: (s: any) => any) =>
-    selector({ config: {}, loadConfig: vi.fn().mockResolvedValue(undefined), updateConfig: vi.fn().mockResolvedValue(undefined) })
+    selector({ config: configFixture, loadConfig: vi.fn().mockResolvedValue(undefined), updateConfig: vi.fn().mockResolvedValue(undefined) })
   )
 }))
 
@@ -61,7 +63,19 @@ vi.mock('@/store/useUIStore', () => ({
 }))
 
 import { useUnifiedRecordings } from '@/hooks/useUnifiedRecordings'
+import { toast } from '@/components/ui/toaster'
 import { Calendar } from '../Calendar'
+
+// The renderer talks to the main process only through window.electronAPI —
+// jsdom has none, so provide the recording surface the Calendar page uses.
+const electronAPI = {
+  recordings: {
+    delete: vi.fn().mockResolvedValue(true),
+    deleteCascade: vi.fn().mockResolvedValue({ success: true, mode: 'soft' }),
+    restore: vi.fn().mockResolvedValue({ success: true })
+  }
+}
+;(window as any).electronAPI = electronAPI
 
 // A viewDate the component will key on; anchoring recording times to it keeps
 // the UTC-based day grouping deterministic across timezones.
@@ -103,6 +117,8 @@ function renderCalendar(recordings: any[], meetings: any[] = []) {
 beforeEach(() => {
   vi.clearAllMocks()
   meetingsFixture = []
+  configFixture = {}
+  window.confirm = vi.fn(() => true)
 })
 
 describe('Calendar — design language', () => {
@@ -156,5 +172,110 @@ describe('Calendar — design language', () => {
     fireEvent.click(screen.getByRole('button', { name: /calendar legend/i }))
     expect(screen.getByText('Recurring / team')).toBeInTheDocument()
     expect(screen.getByText('Not linked to a meeting — click to assign')).toBeInTheDocument()
+  })
+})
+
+// ── Honest deletion (spec-005/F17 T5 §D3b + AR3-4) ──────────────────────────
+// Calendar is a FOURTH delete surface (card grid + compact list), found outside
+// the base spec's enumeration. Its non-device delete buttons must say what they
+// do — soft "Move to Trash" via recordings.deleteCascade(id, false) — and must
+// never route to the legacy permanent recordings.delete IPC (unlinkSync under
+// the hood). AR3-4 (binding): capture-only synthetic rows (localPath === '')
+// render no delete affordance at all.
+
+/** Renders the recordings list page (showListView) instead of the week grid. */
+function renderListView(recordings: any[]) {
+  configFixture = { ui: { showListView: true } }
+  return renderCalendar(recordings)
+}
+
+describe('Calendar — honest deletion (spec-005/F17 T5 §D3b + AR3-4)', () => {
+  it('labels a local-only row "Move to Trash" in the compact list, never "Delete local file"', () => {
+    renderListView([recording({ id: 'r-local', location: 'local-only', localPath: '/x' })])
+
+    expect(screen.getByTitle('Move to Trash')).toBeInTheDocument()
+    expect(screen.queryByTitle('Delete local file')).not.toBeInTheDocument()
+  })
+
+  it('labels a synced (both) row "Move to Trash" in the compact list, never "Delete local copy (keeps on device)"', () => {
+    renderListView([recording({ id: 'r-both', location: 'both', localPath: '/x', deviceFilename: 'rec.hda' })])
+
+    expect(screen.getByTitle('Move to Trash')).toBeInTheDocument()
+    expect(screen.queryByTitle(/Delete local copy/)).not.toBeInTheDocument()
+  })
+
+  it('labels local-only and synced rows "Move to Trash" in the card view too', () => {
+    renderListView([
+      recording({ id: 'r-local', location: 'local-only', localPath: '/x' }),
+      recording({ id: 'r-both', location: 'both', localPath: '/y', deviceFilename: 'rec.hda', dateRecorded: at(11) })
+    ])
+    fireEvent.click(screen.getByTitle('Card view'))
+
+    expect(screen.getAllByTitle('Move to Trash')).toHaveLength(2)
+    expect(screen.queryByTitle('Delete local file')).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/Delete local copy/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the accurate "Delete from device" label for device-only rows', () => {
+    renderListView([recording({ id: 'r-dev', location: 'device-only', localPath: undefined, deviceFilename: 'rec.hda' })])
+
+    expect(screen.getByTitle('Delete from device')).toBeInTheDocument()
+    expect(screen.queryByTitle('Move to Trash')).not.toBeInTheDocument()
+  })
+
+  it('AR3-4: a capture-only synthetic row (no source recording) renders no delete affordance', () => {
+    renderListView([
+      recording({
+        id: 'cap-1',
+        location: 'local-only',
+        localPath: '', // the capture-only marker (see buildRecordingMap)
+        knowledgeCaptureId: 'cap-1',
+        isImported: true,
+        title: 'Imported PDF'
+      })
+    ])
+
+    expect(screen.queryByTitle('Move to Trash')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Delete local file')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('Card view'))
+    expect(screen.queryByTitle('Move to Trash')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Delete local file')).not.toBeInTheDocument()
+  })
+
+  it('routes "Move to Trash" through the soft deleteCascade IPC — never the legacy permanent recordings.delete', async () => {
+    renderListView([recording({ id: 'r-local', location: 'local-only', localPath: '/x' })])
+
+    fireEvent.click(screen.getByTitle('Move to Trash'))
+
+    await waitFor(() => expect(electronAPI.recordings.deleteCascade).toHaveBeenCalledWith('r-local', false))
+    expect(electronAPI.recordings.delete).not.toHaveBeenCalled()
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('to Trash?'))
+  })
+
+  it('shows a "Moved to Trash" toast whose Undo action restores the recording', async () => {
+    renderListView([recording({ id: 'r-undo', location: 'local-only', localPath: '/x' })])
+
+    fireEvent.click(screen.getByTitle('Move to Trash'))
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled())
+    const [title, , opts] = (toast.success as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(title).toBe('Moved to Trash')
+
+    await act(async () => {
+      await opts.action.onClick()
+    })
+    expect(electronAPI.recordings.restore).toHaveBeenCalledWith('r-undo')
+  })
+
+  it('does nothing when the Trash confirm is declined', async () => {
+    ;(window.confirm as ReturnType<typeof vi.fn>).mockReturnValueOnce(false)
+    renderListView([recording({ id: 'r-keep', location: 'local-only', localPath: '/x' })])
+
+    fireEvent.click(screen.getByTitle('Move to Trash'))
+
+    await act(async () => {}) // flush any pending microtasks
+    expect(electronAPI.recordings.deleteCascade).not.toHaveBeenCalled()
+    expect(electronAPI.recordings.delete).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What

Calendar.tsx is a **fourth delete surface** (card grid + compact list inside the recordings list view) that spec-005/F17 T5, its design review, and the Codex adversarial review all failed to enumerate. This PR brings it in line with the honest-deletion model.

## The bug (worse than the dispatched hypothesis)

The task hypothesis was that Calendar''s `handleDeleteLocal` was a soft delete mislabeled as a real delete. **Verified reality is inverted and worse**: it called the legacy `recordings:delete` IPC, which

- permanently `unlinkSync`s the audio file (bypasses the OS recycle bin — "restorable" was never true),
- keeps every derived row (transcript, chunks, embeddings, graph) as ghosts,
- sets `status=''deleted''` with no restore path, and
- looks ids up via `getRecordingById` without `resolveRecordingId`, so synced-row ids from the unified view can silently no-op (return value was ignored).

That hybrid is **neither** of F17''s two sanctioned intents (soft *Move to Trash* / hard *Delete permanently…*), so no tooltip could describe it honestly.

## The fix

- `handleDeleteLocal` now routes through `recordings:deleteCascade(id, false)` — the exact soft path Library uses in production (hide + stop AI processing, restorable, keeps files; resolves synced ids via `resolveRecordingId`).
- Confirm copy and the "Moved to Trash" toast with 8s **Undo** (`recordings:restore`) mirror Library''s, word-for-word with the T5 branch''s `deletionCopy.ts` (consolidation to that module is a follow-up once `claude/f16-f17-value-index-deletion` merges — strings are kept identical so nothing drifts).
- All four button sites (local-only + synced, in card and compact views) now read **"Move to Trash"**; device-only keeps the accurate **"Delete from device"**.
- **AR3-4 (binding)**: capture-only synthetic rows (knowledge captures with `localPath === ''''`) render **no** delete affordance — previously they got a dead "Delete local file" button.

## Coordination with claude/f16-f17-value-index-deletion

- That branch does **not** touch Calendar.tsx; this branch touches nothing it owns (SourceCard/SourceRow/SourceReader/Library) — no textual conflicts either merge order.
- SourceCard''s old labels on beta are that branch''s §D3b fix (verified present there); intentionally not duplicated here.
- Until its Trash surface lands, restore-after-toast relies on the 8s Undo — same situation Library is in on beta today.

## Verification

- TDD: 8 new tests written first and watched fail (7 failed + device-only label guard passed), then implementation — `vitest run src/pages/__tests__/Calendar.test.tsx` → **12/12 pass** (4 pre-existing design tests untouched).
- `npm run typecheck` (node + web) clean; `eslint` on both files clean.
- Covered: label matrix per location, both views, AR3-4 gating, IPC contract (`deleteCascade(id,false)` called, legacy `recordings.delete` **never** called), Undo→restore round-trip, declined confirm.
- No live second-instance smoke test, deliberately: a second Electron instance auto-starts the device service and can seize the HiDock mid-call (USB safety rule). The rerouted IPC bridge is the identical, production-proven path Library ships today.

## Follow-up

After this PR, `recordings:delete` and `recordings:deleteBatch` have **zero renderer callers** — candidates for removal so the dishonest path can''t be reintroduced (task chip filed).