### PR TITLE
test(electron): silence jsdom canvas + pseudo-element noise in renderer suite

### DIFF
--- a/apps/electron/src/__tests__/accessibility/library-a11y.test.tsx
+++ b/apps/electron/src/__tests__/accessibility/library-a11y.test.tsx
@@ -394,6 +394,11 @@ describe('Library Accessibility', () => {
   })
 
   it('should have no color contrast violations', async () => {
+    // NOTE: jsdom has no paint/layout, so axe can only evaluate the computable
+    // subset of color-contrast here (inline/stylesheet colors; text metrics and
+    // pseudo-element backgrounds are stubbed — see src/test/setup.ts). Treat a
+    // pass as "no violations axe could compute", not full WCAG 1.4.3 coverage;
+    // authoritative contrast verification needs a real browser (E2E).
     const { container } = render(
       <MemoryRouter>
         <Library />

--- a/apps/electron/src/test/setup.ts
+++ b/apps/electron/src/test/setup.ts
@@ -54,6 +54,95 @@ if (typeof window !== 'undefined') {
   // Mock scrollIntoView
   window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
+  // jsdom ships no canvas implementation: HTMLCanvasElement#getContext logs
+  // "Not implemented: HTMLCanvasElement's getContext() method: without installing
+  // the canvas npm package" to stderr and returns null, so any component that
+  // draws on mount (WaveformCanvas whenever a test feeds it real audioData)
+  // spams the run output. Return a minimal per-canvas 2D stub instead of
+  // installing the native `canvas` package. Tests that assert on drawing
+  // (WaveformCanvas.test.tsx) vi.spyOn(getContext) over this stub and are
+  // unaffected. Non-'2d' requests (e.g. webgl) return null, silently.
+  // measureText → width 0 also keeps axe-core's icon-ligature probe (the other
+  // getContext caller, via color-contrast in library-a11y.test.tsx) on its
+  // cheap early-return path instead of rasterizing glyphs we can't produce.
+  const context2dByCanvas = new WeakMap<HTMLCanvasElement, CanvasRenderingContext2D>()
+
+  const makeContext2d = (canvas: HTMLCanvasElement): CanvasRenderingContext2D =>
+    ({
+      canvas,
+      fillStyle: '#000',
+      strokeStyle: '#000',
+      lineWidth: 1,
+      globalAlpha: 1,
+      font: '',
+      textAlign: 'left',
+      textBaseline: 'top',
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      clip: vi.fn(),
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      strokeRect: vi.fn(),
+      fillText: vi.fn(),
+      strokeText: vi.fn(),
+      measureText: vi.fn(() => ({ width: 0 })),
+      getImageData: vi.fn((_x: number, _y: number, w: number, h: number) => ({
+        width: w,
+        height: h,
+        data: new Uint8ClampedArray(Math.max(0, Math.floor(w)) * Math.max(0, Math.floor(h)) * 4)
+      })),
+      putImageData: vi.fn(),
+      createImageData: vi.fn((w: number, h: number) => ({
+        width: w,
+        height: h,
+        data: new Uint8ClampedArray(Math.max(0, Math.floor(w)) * Math.max(0, Math.floor(h)) * 4)
+      })),
+      drawImage: vi.fn(),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createPattern: vi.fn(() => null),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      rotate: vi.fn(),
+      setTransform: vi.fn(),
+      resetTransform: vi.fn(),
+      setLineDash: vi.fn(),
+      getLineDash: vi.fn(() => [])
+    }) as unknown as CanvasRenderingContext2D
+
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextId: string
+  ): CanvasRenderingContext2D | null {
+    if (contextId !== '2d') return null
+    let ctx = context2dByCanvas.get(this)
+    if (!ctx) {
+      ctx = makeContext2d(this)
+      context2dByCanvas.set(this, ctx)
+    }
+    return ctx
+  } as typeof HTMLCanvasElement.prototype.getContext
+
+  // jsdom answers getComputedStyle(el, '::before') by IGNORING the pseudo
+  // argument — it logs "Not implemented: Window's getComputedStyle() method:
+  // with pseudo-elements" and then returns the element's own computed style.
+  // axe-core's color-contrast rule probes ::before/::after backgrounds on every
+  // run (dozens of lines across the a11y suite), so drop the pseudo argument up
+  // front: the return value is exactly what jsdom would have produced, minus
+  // the stderr noise. Real pseudo-element styles still can't be asserted in
+  // jsdom — see the note on the color-contrast test in library-a11y.test.tsx.
+  const realGetComputedStyle = window.getComputedStyle.bind(window)
+  window.getComputedStyle = ((elt: Element) =>
+    realGetComputedStyle(elt)) as typeof window.getComputedStyle
+
   // Pointer-capture APIs jsdom doesn't implement — Radix popper components
   // (DropdownMenu, Select, Popover) call these when opening via pointer.
   if (!window.HTMLElement.prototype.hasPointerCapture) {


### PR DESCRIPTION
## Problem

Every full renderer-suite run printed unattributed stderr noise:

```
Not implemented: HTMLCanvasElement's getContext() method: without installing the canvas npm package
```

(4 lines per run, printed before any per-test stderr grouping — which is why they were previously misattributed to `WaveformCanvas.test.tsx` / `Chat.test.tsx`; both mock their canvas access and were never the source.)

## Investigation

A temporary stack-logging wrapper over the real `getContext` attributed all 4 calls:

| Caller | Count | Path |
|---|---|---|
| axe-core `color-contrast` matcher (icon-ligature probe) | 3 | `library-a11y.test.tsx` → `colorContrastMatches` → `_isIconLigature` → `canvas.getContext('2d')` |
| `WaveformCanvas` draw-on-mount effect | 1 | a player test feeding real `audioData` → `WaveformCanvas.tsx:119` |

Two non-obvious findings:

1. **axe's color-contrast rule has never actually evaluated anything in this suite.** With jsdom's `null` context, its matcher throws (`null.canvas`) on every run and axe swallows the error. Enabling the rule in the a11y tests was a no-op.
2. **A canvas stub alone makes things worse, not better.** With a working matcher, the rule reaches its evaluate phase, which probes `::before`/`::after` backgrounds via `getComputedStyle(el, pseudo)` — another jsdom "Not implemented" — trading 4 warnings for **54** (measured).

## Fix (`src/test/setup.ts`, browser-env guard → renderer project only)

- **`HTMLCanvasElement#getContext('2d')`** returns a minimal per-canvas 2D stub (WeakMap-cached) instead of jsdom's warn+null. Tests that assert on drawing (`WaveformCanvas.test.tsx`) `vi.spyOn(getContext)` over the stub and are unaffected. Non-`'2d'` requests still return `null`, now silently.
- **`window.getComputedStyle`** drops the pseudo-element argument. jsdom *ignores that argument anyway* (it logs the warning, then returns the element's own style), so the return value is byte-identical — minus the noise.
- The a11y color-contrast test gets a NOTE documenting that jsdom can only cover the computable subset; authoritative WCAG 1.4.3 verification needs a real browser. No test was disabled, skipped, or weakened.

**Why not the `canvas` npm package:** a second native module (node-gyp/prebuilds, three platforms) to silence log lines — in a repo that just finished wrangling better-sqlite3 ABI issues in CI — and it still wouldn't give axe real layout/paint, so contrast results would remain unsound.

## Evidence

| Run | Before | After |
|---|---|---|
| `vitest run --project renderer` (this branch) | 1969/1969 pass, **4** warnings | 1969/1969 pass, **0** warnings |
| `npm run test:run` (all projects, this branch) | — | **269 files / 3511 tests pass, 0 warnings** |
| `vitest run --project renderer` (main, same patch) | 1778/1778 pass, 4 warnings | 1778/1778 pass, 0 warnings |

Also verified: `npm run typecheck` clean; `eslint` on both changed files clean (0 findings).

## Follow-ups (out of scope here)

- Color contrast is effectively unverified in unit tests (always was); a real-browser (E2E/Playwright) a11y pass would make WCAG 1.4.3 coverage authoritative.
- `npm run lint` reports 106 pre-existing warnings across other files on this line (0 errors; CI passes) — worth a dedicated cleanup pass.
