### PR TITLE
test(electron): de-flake library scroll perf test

### DIFF
--- a/apps/electron/src/__tests__/performance/library-performance.test.tsx
+++ b/apps/electron/src/__tests__/performance/library-performance.test.tsx
@@ -264,10 +264,19 @@ describe('Library Performance', () => {
     })
   })
 
-  // NOTE: Scroll FPS tests have limitations in jsdom
-  // jsdom doesn't trigger real browser rendering, so FPS measurements are synthetic
-  // For accurate scroll performance testing, use Playwright with real browser
-  it('measures scroll interaction timing (jsdom - limited)', async () => {
+  // jsdom cannot measure scroll performance: nothing in this render listens to
+  // scroll (the virtualizer is mocked above and Library attaches no onScroll),
+  // and jsdom's requestAnimationFrame is just a ~16ms timer, so an "FPS"
+  // derived from it measures suite CPU load, not rendering. The previous
+  // version of this test awaited 100 rAF ticks (~2.6s floor even on an idle
+  // machine) and asserted nothing, so the only way it could ever fail was by
+  // tripping the 5s default test timeout — which it did, flakily, under
+  // full-suite load. What jsdom CAN meaningfully check is that a 5000-item
+  // render survives a rapid burst of scroll events, so that is what this
+  // asserts. Real scroll FPS needs Playwright with real browser rendering
+  // (see docs/qa/library-baseline.md). The explicit timeout only covers the
+  // load-sensitive 5000-item initial render; the burst itself is synchronous.
+  it('handles a rapid scroll-event burst over 5000 items without crashing (jsdom smoke)', { timeout: 15_000 }, async () => {
     const recordings = generateMockRecordings(5000)
 
     vi.mocked(useUnifiedRecordings).mockReturnValue({
@@ -292,32 +301,24 @@ describe('Library Performance', () => {
 
     const list = screen.getByTestId('library-list')
 
-    // Measure frame rate during scroll simulation
-    // NOTE: This is NOT real FPS - jsdom doesn't render pixels
-    // Use Playwright for real browser scroll testing
-    const frames: number[] = []
-    let lastTime = performance.now()
-
-    const measureFrame = () => {
-      const now = performance.now()
-      const fps = 1000 / (now - lastTime)
-      frames.push(fps)
-      lastTime = now
-    }
-
-    // Simulate scroll events
+    // Synchronous dispatch — fireEvent runs scroll handling and React commits
+    // inline, so timer waits between events would add wall-clock, not coverage.
+    const start = performance.now()
     for (let i = 0; i < 100; i++) {
       list.scrollTop += 50
       fireEvent.scroll(list)
-      await new Promise(r => requestAnimationFrame(r))
-      measureFrame()
     }
+    const elapsed = performance.now() - start
 
-    const avgFps = frames.reduce((a, b) => a + b, 0) / frames.length
-    console.log(`Average simulated scroll FPS: ${avgFps.toFixed(2)} (jsdom - not real rendering)`)
+    console.log(`100 scroll events dispatched in ${elapsed.toFixed(2)}ms (jsdom - informational only, not asserted)`)
 
-    // This test provides timing data but not real FPS
-    // For production, implement Playwright scroll tests
+    // Correctness: the list survives the burst. waitFor is act-aware, so it
+    // also flushes Library's pending async state updates (mocked-promise
+    // effects) inside act — a plain sync expect leaves them to land after the
+    // test returns and triggers "not wrapped in act" warnings.
+    await waitFor(() => {
+      expect(screen.getByTestId('library-list')).toBeInTheDocument()
+    })
   })
 
   it('applies filters within performance budget', async () => {

--- a/docs/qa/library-baseline.md
+++ b/docs/qa/library-baseline.md
@@ -92,8 +92,8 @@ npm run test:performance
       Filter application time: XX.XXms
     ✓ switches view modes within performance budget
       View switch time: XX.XXms
-    ✓ measures scroll interaction timing (jsdom - limited)
-      Average simulated scroll FPS: XX.XX (jsdom - not real rendering)
+    ✓ handles a rapid scroll-event burst over 5000 items without crashing (jsdom smoke)
+      100 scroll events dispatched in XX.XXms (jsdom - informational only, not asserted)
 ```
 
 ## Analysis

--- a/docs/qa/library-baseline.md
+++ b/docs/qa/library-baseline.md
@@ -80,8 +80,8 @@ npm run test:performance
 ### Sample Output
 
 ```
-✓ src/__tests__/performance/library-performance.test.ts (5)
-  ✓ Library Performance (5)
+✓ src/__tests__/performance/library-performance.test.tsx (6)
+  ✓ Library Performance (6)
     ✓ renders 100 items within performance budget
       Render time for 100 items: XX.XXms
     ✓ renders 1000 items within performance budget

--- a/plans/library-todos/todo-013-performance-baseline.md
+++ b/plans/library-todos/todo-013-performance-baseline.md
@@ -2,6 +2,14 @@
 
 ## Status: PENDING
 
+> **2026-07-14 update:** The jsdom scroll test sketched in Step 2 was implemented and
+> later rewritten (`library-performance.test.tsx`): awaiting 100 `requestAnimationFrame`
+> ticks in jsdom produced a ~2.6s wall-clock floor and a synthetic FPS number with no
+> assertion, which flaked against the 5s default test timeout under full-suite load.
+> It is now a synchronous scroll-burst smoke test ("handles a rapid scroll-event burst
+> over 5000 items without crashing"). The "Scroll FPS measured with 5000 items"
+> acceptance criterion still requires the Playwright real-browser test recommended below.
+
 ## Phase: 2 (Validation - NEW)
 
 ## Priority: HIGH


### PR DESCRIPTION
## Problem

`library-performance.test.tsx > measures scroll interaction timing (jsdom - limited)` was flaky under machine load: it passed in isolation and in most full-suite runs, but intermittently failed with **"Test timed out in 5000ms"** when the full apps/electron suite ran concurrently.

## Root cause

- The test awaited 100 `requestAnimationFrame` ticks. In jsdom, rAF is just a ~16ms `setTimeout` — a **~2.6s wall-clock floor even on an idle machine** (measured: the test took 2971ms in isolation), and timers only dilate under CPU contention.
- The config sets no `testTimeout`, so vitest's **default 5000ms** applied. Under full-suite load, 2971ms → >5000ms is expected behavior.
- The test **asserted nothing** — it computed a synthetic "FPS" (its own comments concede jsdom doesn't render, so the number measures machine load) and logged it. Timing out was the *only* way this test could fail.
- Nothing in the render even listens to scroll: the virtualizer is mocked in this file and `Library` attaches no `onScroll`, so the 100 scroll events exercised no scroll-handling code between "frames".

## Fix

Rewritten following the same pattern previously used to de-flake its siblings (`applies filters`, `switches view modes`): synchronous work, correctness asserted untimed, budgets documented.

- Drop the rAF/FPS loop entirely; dispatch the 100-event scroll burst synchronously (11.8ms measured, logged informationally, not asserted).
- Add the correctness assertion the test never had: the list survives the burst, via an act-aware `waitFor` — which also flushes Library's pending async state updates inside `act`, eliminating this test's pre-existing "not wrapped in act(...)" stderr warnings.
- Explicit `{ timeout: 15_000 }` covering the load-sensitive 5000-item initial render, with a comment explaining the history.
- Updated `docs/qa/library-baseline.md` sample output and annotated `plans/library-todos/todo-013-performance-baseline.md`; real scroll-FPS measurement remains a Playwright (real browser) concern, as both docs already recommend.

## Verification

- Isolated file: 6/6 pass; scroll test duration **2971ms → ~190ms**; `act` warnings 2 → 0.
- Full suite twice locally (Windows): **217 files / 2898 tests passed, both runs**.
- `typecheck:web` clean; `eslint` clean on the changed file.