### PR TITLE
test(electron): stop temp-DB/file leaks from the vitest suite

### DIFF
--- a/apps/electron/electron/main/services/__tests__/config-brains-migration.test.ts
+++ b/apps/electron/electron/main/services/__tests__/config-brains-migration.test.ts
@@ -3,13 +3,33 @@
  *
  * @vitest-environment node
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdirSync, rmSync } from 'fs'
 
-vi.mock('electron', () => ({
-  app: { getPath: () => tmpdir() },
-  safeStorage: { isEncryptionAvailable: () => false },
-}))
+// Isolated per-process userData dir — see config-features-default.test.ts:
+// sharing the tmpdir ROOT leaked %TEMP%/config.json and coupled the real-fs
+// config suites to each other across parallel workers and runs.
+function testUserDataDir(): string {
+  return join(tmpdir(), `hidock-config-brains-migration-test-${process.pid}`)
+}
+
+vi.mock('electron', () => {
+  // config.ts resolves its paths as soon as it is imported — the dir must
+  // exist (and be empty) before that happens.
+  const dir = testUserDataDir()
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+  return {
+    app: { getPath: () => testUserDataDir() },
+    safeStorage: { isEncryptionAvailable: () => false },
+  }
+})
+
+afterAll(() => {
+  rmSync(testUserDataDir(), { recursive: true, force: true })
+})
 
 // Stateful credential-store mock. `storeState` mirrors the on-disk secret map so
 // getSecret/setSecret behave like the real store, and `setSecretShouldFail`

--- a/apps/electron/electron/main/services/__tests__/config-features-default.test.ts
+++ b/apps/electron/electron/main/services/__tests__/config-features-default.test.ts
@@ -4,13 +4,34 @@
  *
  * @vitest-environment node
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterAll } from 'vitest'
 import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdirSync, rmSync } from 'fs'
 
-vi.mock('electron', () => ({
-  app: { getPath: () => tmpdir() },
-  safeStorage: { isEncryptionAvailable: () => false },
-}))
+// Isolated per-process userData dir. Pointing userData at the tmpdir ROOT (as
+// before) made every real-fs config suite share one %TEMP%/config.json across
+// files and runs — leaking the file and letting parallel workers see each
+// other's writes. A function declaration so the hoisted mock factory can call it.
+function testUserDataDir(): string {
+  return join(tmpdir(), `hidock-config-features-test-${process.pid}`)
+}
+
+vi.mock('electron', () => {
+  // config.ts resolves its paths as soon as it is imported — the dir must
+  // exist (and be empty) before that happens.
+  const dir = testUserDataDir()
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+  return {
+    app: { getPath: () => testUserDataDir() },
+    safeStorage: { isEncryptionAvailable: () => false },
+  }
+})
+
+afterAll(() => {
+  rmSync(testUserDataDir(), { recursive: true, force: true })
+})
 
 vi.mock('../brains/brain-credential-store', () => ({
   getBrainCredentialStore: () => ({

--- a/apps/electron/electron/main/services/__tests__/temp-db-tracker.test.ts
+++ b/apps/electron/electron/main/services/__tests__/temp-db-tracker.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Temp-DB hygiene wiring, end-to-end: this file runs in the `main-db` vitest
+ * project, so the better-sqlite3 import below goes through the setup-db.ts
+ * dual-ABI shim, which wraps the constructor with trackDatabases(). Every
+ * handle a DB-backed test opens must therefore be recorded, and
+ * sweepTempDbs() — the setup-file afterAll calls it for every main-db test
+ * file — must close the handles and delete the tmpdir()-hosted DB files.
+ *
+ * Without this, DB-backed suites stranded their per-test temp SQLite files
+ * (`hidock-*-test-*.sqlite` plus -wal/-shm siblings) in %TEMP% forever:
+ * thousands of files accumulated, because nothing ever closed the handles
+ * DatabaseEngine.initialize() leaves behind on re-init, and on Windows an
+ * open better-sqlite3 handle makes rmSync fail with EPERM anyway.
+ *
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { existsSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { sweepTempDbs } from '../../../../src/test/temp-db-tracker'
+
+function tempDbPath(tag: string): string {
+  return join(tmpdir(), `hidock-tracker-test-${tag}-${process.pid}-${Date.now()}.sqlite`)
+}
+
+describe('temp-db-tracker (via the setup-db better-sqlite3 shim)', () => {
+  it('closes open handles and deletes tmpdir DB files including WAL siblings', () => {
+    const p1 = tempDbPath('wal')
+    const p2 = tempDbPath('stranded')
+    const db1 = new Database(p1)
+    db1.pragma('journal_mode = WAL')
+    db1.exec('CREATE TABLE t (x); INSERT INTO t VALUES (1)')
+    // Second handle left open on purpose — mirrors DatabaseEngine.initialize()
+    // stranding the previous handle when a test re-initializes per test.
+    const db2 = new Database(p2)
+    expect(existsSync(p1)).toBe(true)
+    expect(existsSync(`${p1}-wal`)).toBe(true)
+    expect(existsSync(p2)).toBe(true)
+
+    const result = sweepTempDbs()
+
+    expect(db1.open).toBe(false)
+    expect(db2.open).toBe(false)
+    expect(result.closed).toBe(2)
+    for (const f of [p1, `${p1}-wal`, `${p1}-shm`, p2]) {
+      expect(existsSync(f), f).toBe(false)
+    }
+  })
+
+  it('deletes date-stamped boot-backup siblings (<db>.bak-YYYY-MM-DD)', () => {
+    // DatabaseEngine.backupOnBoot() copies `<db>.bak-<date>` next to an
+    // existing DB before reopening it — reopen-style suites leaked these.
+    const p = tempDbPath('bak')
+    const db = new Database(p)
+    db.exec('CREATE TABLE t (x)')
+    const bak = `${p}.bak-2026-01-01`
+    writeFileSync(bak, 'backup')
+
+    sweepTempDbs()
+
+    expect(db.open).toBe(false)
+    expect(existsSync(p)).toBe(false)
+    expect(existsSync(bak)).toBe(false)
+  })
+
+  it('tolerates handles the test already closed and files already removed', () => {
+    const p = tempDbPath('pre-closed')
+    const db = new Database(p)
+    db.exec('CREATE TABLE t (x)')
+    db.close()
+    rmSync(p, { force: true })
+
+    expect(() => sweepTempDbs()).not.toThrow()
+    expect(existsSync(p)).toBe(false)
+  })
+
+  it('closes but never deletes a DB file outside os.tmpdir()', () => {
+    const outside = join(process.cwd(), `tracker-guard-${process.pid}.sqlite`)
+    const db = new Database(outside)
+    try {
+      db.exec('CREATE TABLE t (x)')
+      sweepTempDbs()
+      expect(db.open).toBe(false)
+      expect(existsSync(outside)).toBe(true)
+    } finally {
+      try { rmSync(outside, { force: true }) } catch { /* best-effort */ }
+    }
+  })
+
+  it('keeps tracking across vi.resetModules() — fresh tracker instances share state', async () => {
+    // database.test.ts resets the module registry between lifecycle tests; a
+    // module-scoped tracked list would orphan handles opened before the reset.
+    const p = tempDbPath('reset')
+    const db = new Database(p)
+    db.exec('CREATE TABLE t (x)')
+
+    vi.resetModules()
+    const fresh = await import('../../../../src/test/temp-db-tracker')
+    fresh.sweepTempDbs()
+
+    expect(db.open).toBe(false)
+    expect(existsSync(p)).toBe(false)
+  })
+
+  it('closes :memory: handles without touching the filesystem', () => {
+    const db = new Database(':memory:')
+    db.exec('CREATE TABLE t (x)')
+    expect(() => sweepTempDbs()).not.toThrow()
+    expect(db.open).toBe(false)
+  })
+})

--- a/apps/electron/electron/main/services/brains/__tests__/cli-runner.test.ts
+++ b/apps/electron/electron/main/services/brains/__tests__/cli-runner.test.ts
@@ -449,11 +449,16 @@ describe('Windows executable resolution (HIGH-1)', () => {
   }, 20000)
 
   itWin('runCli resolves spawnError when a bare name is not found on PATH', async () => {
-    const res = await runCli('definitely-not-a-real-binary-xyz', [], {
-      timeoutMs: 5000,
-      env: { PATH: mkdtempSync(join(tmpdir(), 'empty-')) },
-    })
-    expect(res.spawnError).toBe(true)
+    const emptyDir = mkdtempSync(join(tmpdir(), 'empty-'))
+    try {
+      const res = await runCli('definitely-not-a-real-binary-xyz', [], {
+        timeoutMs: 5000,
+        env: { PATH: emptyDir },
+      })
+      expect(res.spawnError).toBe(true)
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/apps/electron/electron/main/services/connectors/__tests__/ingestion.test.ts
+++ b/apps/electron/electron/main/services/connectors/__tests__/ingestion.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
+import { readdirSync } from 'fs'
+import { tmpdir } from 'os'
 
 // Replace the electron-dependent modules so importing ingestion.ts doesn't pull
 // in config.ts (which calls app.getPath at module load). The sink under test is
@@ -98,9 +100,14 @@ describe('ConnectorIngestionSink routing', () => {
     const items: SourceItem[] = [
       { externalId: 'x', kind: 'image', mime: 'image/png', createdAt: '2026-07-09T00:00:00Z' },
     ]
+    // stageArtifact mkdtemps its staging dir BEFORE it knows the item is
+    // unfetchable — a skipped item must not strand that dir in %TEMP%.
+    const before = new Set(readdirSync(tmpdir()).filter((n) => n.startsWith('hidock-conn-')))
     const outcome = await sink.ingest('slack', container, items)
     expect(outcome.artifacts).toBe(0)
     expect(outcome.skipped).toBe(1)
+    const leaked = readdirSync(tmpdir()).filter((n) => n.startsWith('hidock-conn-') && !before.has(n))
+    expect(leaked).toEqual([])
   })
 
   it('batches multiple meetings into a single upsert call', async () => {

--- a/apps/electron/electron/main/services/connectors/ingestion.ts
+++ b/apps/electron/electron/main/services/connectors/ingestion.ts
@@ -161,8 +161,12 @@ export class ConnectorIngestionSink implements IngestionSink {
     const filePath = join(dir, `${safeName}.${extensionForItem(item)}`)
 
     if (item.text != null) {
-      writeFileSync(filePath, item.text, 'utf-8')
-      return filePath
+      try {
+        writeFileSync(filePath, item.text, 'utf-8')
+        return filePath
+      } catch {
+        return discard()
+      }
     }
     if (item.url) {
       try {

--- a/apps/electron/electron/main/services/connectors/ingestion.ts
+++ b/apps/electron/electron/main/services/connectors/ingestion.ts
@@ -147,6 +147,16 @@ export class ConnectorIngestionSink implements IngestionSink {
   /** Stage an artifact item to a temp file; returns the path or null if unfetchable. */
   private async stageArtifact(item: SourceItem): Promise<string | null> {
     const dir = mkdtempSync(join(tmpdir(), 'hidock-conn-'))
+    // The dir exists before we know the item is fetchable — every null return
+    // must discard it or unfetchable items strand hidock-conn-* dirs in TEMP.
+    const discard = (): null => {
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {
+        /* best-effort temp cleanup */
+      }
+      return null
+    }
     const safeName = (item.externalId || randomUUID()).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64)
     const filePath = join(dir, `${safeName}.${extensionForItem(item)}`)
 
@@ -159,14 +169,14 @@ export class ConnectorIngestionSink implements IngestionSink {
         const headers: Record<string, string> = {}
         if (item.fetchAuthorization) headers.Authorization = item.fetchAuthorization
         const res = await fetch(item.url, { headers })
-        if (!res.ok) return null
+        if (!res.ok) return discard()
         writeFileSync(filePath, Buffer.from(await res.arrayBuffer()))
         return filePath
       } catch {
-        return null
+        return discard()
       }
     }
-    return null
+    return discard()
   }
 }
 

--- a/apps/electron/src/test/setup-db.ts
+++ b/apps/electron/src/test/setup-db.ts
@@ -18,8 +18,14 @@
  *
  * Version skew between the two copies is guarded by the version-pin test in
  * better-sqlite3-binding.smoke.test.ts.
+ *
+ * The shim also wraps the constructor with trackDatabases() and sweeps in an
+ * afterAll: DB-backed suites mint fresh temp SQLite files per test and never
+ * deleted them (8000+ hidock-*-test-*.sqlite files piled up in %TEMP%), so
+ * every handle is tracked and its tmpdir()-hosted files are removed once the
+ * test file is done — see temp-db-tracker.ts.
  */
-import { vi } from 'vitest'
+import { vi, afterAll } from 'vitest'
 
 vi.mock('better-sqlite3', async () => {
   const { createRequire } = await import('module')
@@ -30,5 +36,17 @@ vi.mock('better-sqlite3', async () => {
   // setup-db.ts lives at apps/electron/src/test/ → repo root is four levels up.
   const nodeAbiCopy = resolve(here, '../../../../packages/database/node_modules/better-sqlite3')
   const Database = req(nodeAbiCopy)
-  return { default: Database }
+  const { trackDatabases } = await import('./temp-db-tracker')
+  return { default: trackDatabases(Database) }
+})
+
+// Temp-DB hygiene: this setup module is evaluated once per test FILE, so this
+// afterAll runs after each file's own hooks finish. The one-macrotask defer
+// keeps the sweep after a file's own synchronous afterAll cleanup regardless
+// of vitest's hook ordering, so suites that close/delete their DB themselves
+// always get to run first.
+afterAll(async () => {
+  await new Promise((tick) => setImmediate(tick))
+  const { sweepTempDbs } = await import('./temp-db-tracker')
+  sweepTempDbs()
 })

--- a/apps/electron/src/test/temp-db-tracker.ts
+++ b/apps/electron/src/test/temp-db-tracker.ts
@@ -1,0 +1,140 @@
+/**
+ * Temp-DB tracker for the `main-db` vitest project (main-process, DB-backed
+ * tests). setup-db.ts wraps the shim's better-sqlite3 constructor with
+ * trackDatabases(), so every handle a test file opens — and the file it
+ * points at — is recorded here; sweepTempDbs() runs from a setup-file
+ * afterAll, closes whatever is still open, and deletes the tracked DB files.
+ *
+ * Why this exists: DB-backed test files mint fresh SQLite paths under
+ * os.tmpdir() (e.g. `hidock-kg-test-${Date.now()}-${n}.sqlite`) and re-run
+ * initializeDatabase() per test. DatabaseEngine.initialize() does NOT close
+ * the previously-open handle, and no suite ever deleted the minted files —
+ * one full run stranded ~90 files, and %TEMP% accumulated 8000+ of them over
+ * time. Tracking at the constructor is the one choke point that covers every
+ * DB-backed suite (and future ones) without per-file cleanup code.
+ *
+ * Ordering constraint: handles MUST be closed before deleting. better-sqlite3
+ * holds a native file handle, and on Windows rmSync on an open DB fails with
+ * EPERM — which is also why closing only the engine's current handle would
+ * not be enough (the stranded ones would keep their files locked).
+ *
+ * Safety: only files that resolve inside os.tmpdir() are deleted. Anything
+ * else (repo-relative fixtures, ':memory:', anonymous DBs) is closed but
+ * never touched on disk.
+ */
+import { existsSync, readdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { basename, dirname, join, resolve, sep } from 'path'
+
+interface SqliteHandle {
+  readonly open: boolean
+  close(): unknown
+}
+
+interface TrackedDb {
+  handle: SqliteHandle
+  /** Resolved absolute DB file path; '' when the DB is not file-backed. */
+  file: string
+}
+
+// The tracked list lives on globalThis, NOT at module scope: suites that call
+// vi.resetModules() (e.g. database.test.ts's isolated-lifecycle block) make
+// the next better-sqlite3 import re-evaluate this module, and a module-scoped
+// array would strand every handle the orphaned instance tracked — the sweep
+// would then see a fresh, empty list. globalThis survives registry resets.
+const GLOBAL_KEY = Symbol.for('hidock.temp-db-tracker.tracked')
+const globalStore = globalThis as Record<symbol, TrackedDb[] | undefined>
+const tracked: TrackedDb[] = (globalStore[GLOBAL_KEY] ??= [])
+
+/** Files better-sqlite3/SQLite may create next to a database file. */
+const DB_FILE_SUFFIXES = ['', '-wal', '-shm', '-journal']
+
+/**
+ * Wrap the better-sqlite3 constructor so every instance (and the file it
+ * opens) is recorded for the end-of-file sweep. Plain calls are routed
+ * through the construct trap so they are tracked exactly once.
+ */
+export function trackDatabases<T extends object>(Database: T): T {
+  const proxy = new Proxy(Database, {
+    construct(target, args: unknown[], newTarget) {
+      const instance = Reflect.construct(target as new (...a: unknown[]) => object, args, newTarget)
+      const filename = typeof args[0] === 'string' ? args[0] : ''
+      const fileBacked = filename !== '' && filename !== ':memory:'
+      tracked.push({ handle: instance as SqliteHandle, file: fileBacked ? resolve(filename) : '' })
+      return instance
+    },
+    apply(_target, _thisArg, args: unknown[]) {
+      return Reflect.construct(proxy as unknown as new (...a: unknown[]) => object, args)
+    },
+  })
+  return proxy as T
+}
+
+/**
+ * Close every tracked handle that is still open, then delete the tracked
+ * temp DB files (and their -wal/-shm/-journal siblings). Returns counts so
+ * the wiring can be asserted in tests. Handles a test already closed and
+ * files a test already removed are fine; files outside os.tmpdir() are
+ * never deleted.
+ */
+export function sweepTempDbs(): { closed: number; deleted: number } {
+  const tempRoot = resolve(tmpdir()) + sep
+  let closed = 0
+  let deleted = 0
+  const files: string[] = []
+  for (const db of tracked.splice(0)) {
+    try {
+      if (db.handle.open) {
+        db.handle.close()
+        closed++
+      }
+    } catch {
+      /* best-effort: per-file deletion below stays guarded */
+    }
+    if (db.file !== '' && db.file.startsWith(tempRoot) && !files.includes(db.file)) files.push(db.file)
+  }
+
+  for (const file of files) {
+    for (const suffix of DB_FILE_SUFFIXES) {
+      const sibling = file + suffix
+      try {
+        if (existsSync(sibling)) {
+          rmSync(sibling, { force: true })
+          deleted++
+        }
+      } catch {
+        /* e.g. a concurrent worker still holds this file open — leave it */
+      }
+    }
+  }
+
+  // DatabaseEngine.backupOnBoot() copies `<db>.bak-<YYYY-MM-DD>` next to a
+  // pre-existing DB before reopening it. The suffix is date-stamped, so match
+  // by prefix — one readdir per parent dir, not one per tracked file (%TEMP%
+  // can hold tens of thousands of entries).
+  const bakPrefixesByDir = new Map<string, string[]>()
+  for (const file of files) {
+    const dir = dirname(file)
+    const prefixes = bakPrefixesByDir.get(dir) ?? []
+    prefixes.push(`${basename(file)}.bak-`)
+    bakPrefixesByDir.set(dir, prefixes)
+  }
+  for (const [dir, prefixes] of bakPrefixesByDir) {
+    let names: string[]
+    try {
+      names = readdirSync(dir)
+    } catch {
+      continue
+    }
+    for (const name of names) {
+      if (!prefixes.some((prefix) => name.startsWith(prefix))) continue
+      try {
+        rmSync(join(dir, name), { force: true })
+        deleted++
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  return { closed, deleted }
+}

--- a/apps/electron/tsconfig.node.json
+++ b/apps/electron/tsconfig.node.json
@@ -4,7 +4,8 @@
     "electron.vite.config.*",
     "electron/**/*",
     "src/types/**/*",
-    "src/shared/**/*"
+    "src/shared/**/*",
+    "src/test/temp-db-tracker.ts"
   ],
   "exclude": [
     "electron/main/services/__tests__/benchmark.test.ts"


### PR DESCRIPTION
## Problem

Every full electron test run stranded ~90 files in `%TEMP%` and never deleted them — 8,600+ `hidock-*` files had accumulated (3,021 `ctxmut`, 2,969 `ctxgraph`, 1,628 `valuegates`, 340 `graph-prov`, 272 `kg`, 167 `dbtest-iso`, …). Root causes:

- DB-backed main-process suites mint a fresh `tmpdir()` SQLite path per test (`getDatabasePath` mocks) and re-run `initializeDatabase()`; `DatabaseEngine.initialize()` never closes the previous handle, so per-file `closeDatabase()` cleanup could not work anyway — on Windows an open better-sqlite3 handle makes `rmSync` fail with EPERM.
- Reopen-style suites additionally minted `<db>.bak-<date>` boot backups (`backupOnBoot`).
- Stragglers: `stageArtifact()` stranded its `hidock-conn-*` staging dir on every unfetchable item (production leak too), the real-fs config suites shared one `%TEMP%/config.json` (leak + cross-worker coupling), and cli-runner leaked its `empty-*` PATH dir.

## Fix

**Central sweep instead of editing ~15 suites:** `setup-db.ts` — the dual-ABI shim loaded by exactly the `main-db` vitest project — now wraps the better-sqlite3 constructor with `trackDatabases()` (new `src/test/temp-db-tracker.ts`). A setup-level `afterAll` closes every handle still open, then deletes tracked files that resolve inside `os.tmpdir()`, including `-wal`/`-shm`/`-journal` and date-stamped `.bak-*` siblings. The tracked list lives on `globalThis` so `vi.resetModules()` suites (database.test.ts lifecycle block) can't orphan handles. This automatically covers every current **and future** DB-backed suite — e.g. the F16 `value-gates`/`graph-provenance` suites the moment that branch merges.

Safety: only paths inside `os.tmpdir()` are ever deleted; anything else is closed but left on disk. The sweep defers one macrotask so a suite's own `afterAll` cleanup always runs first.

**Stragglers:** `ingestion.ts` discards the staging dir on every null return; the two config suites get an isolated per-process `userData` dir (rm'd in `afterAll`); cli-runner removes its temp PATH dir.

## Verification

Measured by pointing `TEMP`/`TMP` at a fresh private dir for the whole run (immune to concurrent sessions):

- **Before:** 8 leftover artifact groups per run — 84 counter-pattern sqlite files, a `.bak`, `hidock-conn-*`, `config.json`, `empty-*`.
- **After:** nothing but `node-compile-cache/` (Node's own) and the stable, **empty** `hidock-clipboard/` staging dir.
- Full suite: **270/270 files, 3,517/3,517 tests green** (exit 0). `npm run typecheck` and `npm run lint` green; zero eslint findings on touched files.
- New coverage: `temp-db-tracker.test.ts` (6 cases: WAL siblings, stranded handles, `.bak` siblings, pre-closed handles, outside-tmpdir guard, `vi.resetModules()` survival) + a leak assertion in the ingestion skip-path test.

## Follow-up (out of scope)

`DatabaseEngine.initialize()` overwrites `this.bdb` without closing a previously-open handle — harmless at app boot (called once) but the enabler of the stranded-handle pattern in tests. Worth a guarded close-on-reinit in `packages/database`.