### PR TITLE
refactor(electron): remove legacy recordings:delete/deleteBatch IPC path

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -262,7 +262,7 @@
         "filename": "apps\\electron\\electron\\main\\ipc\\__tests__\\recording-handlers.test.ts",
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 129
       }
     ],
     "apps\\electron\\electron\\main\\services\\__tests__\\transcription.test.ts": [
@@ -843,5 +843,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-10T18:16:37Z"
+  "generated_at": "2026-07-14T15:07:15Z"
 }

--- a/apps/electron/electron/main/ipc/__tests__/recording-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/recording-handlers.test.ts
@@ -37,7 +37,6 @@ vi.mock('../../services/database', () => ({
 // Mock file-storage service
 vi.mock('../../services/file-storage', () => ({
   getRecordingFiles: vi.fn(),
-  deleteRecording: vi.fn(),
   getRecordingsPath: vi.fn(() => '/mock/recordings')
 }))
 
@@ -96,26 +95,6 @@ function createSchemaMock(idField: string | string[]) {
 // Mock validation schemas
 vi.mock('../validation', () => ({
   GetRecordingByIdSchema: createSchemaMock('id'),
-  DeleteRecordingSchema: createSchemaMock('id'),
-  DeleteBatchRecordingsSchema: {
-    safeParse: vi.fn((data: any) => {
-      if (!data?.ids || !Array.isArray(data.ids)) {
-        return { success: false, error: { issues: [{ message: 'ids must be an array' }] } }
-      }
-      if (data.ids.length === 0) {
-        return { success: false, error: { issues: [{ message: 'ids must have at least 1 element' }] } }
-      }
-      if (data.ids.length > 1000) {
-        return { success: false, error: { issues: [{ message: 'ids must have at most 1000 elements' }] } }
-      }
-      for (const id of data.ids) {
-        if (!UUID_RE.test(id)) {
-          return { success: false, error: { issues: [{ message: 'Each ID must be a valid UUID' }] } }
-        }
-      }
-      return { success: true, data }
-    })
-  },
   LinkRecordingToMeetingSchema: createSchemaMock(['recordingId', 'meetingId']),
   UnlinkRecordingFromMeetingSchema: createSchemaMock('recordingId'),
   TranscribeRecordingSchema: createSchemaMock('recordingId'),
@@ -175,8 +154,6 @@ describe('Recording IPC Handlers', () => {
       'recordings:getById',
       'recordings:getForMeeting',
       'recordings:getAllWithTranscripts',
-      'recordings:delete',
-      'recordings:deleteBatch',
       'recordings:linkToMeeting',
       'recordings:unlinkFromMeeting',
       'recordings:getTranscript',
@@ -323,142 +300,6 @@ describe('Recording IPC Handlers', () => {
       const result = await handlers['recordings:getAllWithTranscripts'](null)
 
       expect(result).toEqual([])
-    })
-  })
-
-  describe('recordings:delete', () => {
-    it('should delete a recording file and update its status', async () => {
-      const { getRecordingById, updateRecordingStatus } = await import('../../services/database')
-      const { deleteRecording } = await import('../../services/file-storage')
-      const id = '550e8400-e29b-41d4-a716-446655440000'
-      vi.mocked(getRecordingById).mockReturnValue({
-        id,
-        file_path: '/path/to/file.wav',
-        filename: 'file.wav'
-      } as any)
-      vi.mocked(deleteRecording).mockReturnValue(true)
-
-      const result = await handlers['recordings:delete'](null, id)
-
-      expect(deleteRecording).toHaveBeenCalledWith('/path/to/file.wav')
-      expect(updateRecordingStatus).toHaveBeenCalledWith(id, 'deleted')
-      expect(result).toBe(true)
-    })
-
-    it('should return false if recording not found', async () => {
-      const { getRecordingById } = await import('../../services/database')
-      const id = '550e8400-e29b-41d4-a716-446655440000'
-      vi.mocked(getRecordingById).mockReturnValue(undefined)
-
-      const result = await handlers['recordings:delete'](null, id)
-
-      expect(result).toBe(false)
-    })
-
-    it('should not update status if file deletion fails', async () => {
-      const { getRecordingById, updateRecordingStatus } = await import('../../services/database')
-      const { deleteRecording } = await import('../../services/file-storage')
-      const id = '550e8400-e29b-41d4-a716-446655440000'
-      vi.mocked(getRecordingById).mockReturnValue({
-        id,
-        file_path: '/path/to/file.wav',
-        filename: 'file.wav'
-      } as any)
-      vi.mocked(deleteRecording).mockReturnValue(false)
-
-      const result = await handlers['recordings:delete'](null, id)
-
-      expect(updateRecordingStatus).not.toHaveBeenCalled()
-      expect(result).toBe(false)
-    })
-
-    it('should return false for invalid ID format', async () => {
-      const result = await handlers['recordings:delete'](null, 'not-a-uuid')
-
-      expect(result).toBe(false)
-    })
-
-    it('should return false on error', async () => {
-      const { getRecordingById } = await import('../../services/database')
-      const id = '550e8400-e29b-41d4-a716-446655440000'
-      vi.mocked(getRecordingById).mockImplementation(() => {
-        throw new Error('DB error')
-      })
-
-      const result = await handlers['recordings:delete'](null, id)
-
-      expect(result).toBe(false)
-    })
-  })
-
-  describe('recordings:deleteBatch', () => {
-    it('should delete multiple recordings and return results', async () => {
-      const { getRecordingById } = await import('../../services/database')
-      const { deleteRecording } = await import('../../services/file-storage')
-
-      const id1 = '550e8400-e29b-41d4-a716-446655440000'
-      const id2 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-
-      vi.mocked(getRecordingById)
-        .mockReturnValueOnce({ id: id1, file_path: '/path/file1.wav', filename: 'file1.wav' } as any)
-        .mockReturnValueOnce({ id: id2, file_path: '/path/file2.wav', filename: 'file2.wav' } as any)
-      vi.mocked(deleteRecording).mockReturnValue(true)
-
-      const result = await handlers['recordings:deleteBatch'](null, [id1, id2])
-
-      expect(result.success).toBe(true)
-      expect(result.deleted).toBe(2)
-      expect(result.failed).toBe(0)
-      expect(result.errors).toEqual([])
-    })
-
-    it('should return partial results when some deletions fail', async () => {
-      const { getRecordingById } = await import('../../services/database')
-      const { deleteRecording } = await import('../../services/file-storage')
-
-      const id1 = '550e8400-e29b-41d4-a716-446655440000'
-      const id2 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
-
-      vi.mocked(getRecordingById)
-        .mockReturnValueOnce({ id: id1, file_path: '/path/file1.wav', filename: 'file1.wav' } as any)
-        .mockReturnValueOnce(undefined) // second recording not found
-
-      vi.mocked(deleteRecording).mockReturnValue(true)
-
-      const result = await handlers['recordings:deleteBatch'](null, [id1, id2])
-
-      expect(result.success).toBe(false)
-      expect(result.deleted).toBe(1)
-      expect(result.failed).toBe(1)
-      expect(result.errors).toHaveLength(1)
-    })
-
-    it('should reject invalid IDs', async () => {
-      const result = await handlers['recordings:deleteBatch'](null, ['not-a-uuid'])
-
-      expect(result.success).toBe(false)
-      expect(result.deleted).toBe(0)
-    })
-
-    it('should reject empty array', async () => {
-      const result = await handlers['recordings:deleteBatch'](null, [])
-
-      expect(result.success).toBe(false)
-    })
-
-    it('should handle errors gracefully', async () => {
-      const { getRecordingById } = await import('../../services/database')
-      const id1 = '550e8400-e29b-41d4-a716-446655440000'
-
-      vi.mocked(getRecordingById).mockImplementation(() => {
-        throw new Error('DB error')
-      })
-
-      const result = await handlers['recordings:deleteBatch'](null, [id1])
-
-      expect(result.success).toBe(false)
-      expect(result.failed).toBe(1)
-      expect(result.errors[0].error).toBe('DB error')
     })
   })
 

--- a/apps/electron/electron/main/ipc/recording-handlers.ts
+++ b/apps/electron/electron/main/ipc/recording-handlers.ts
@@ -21,7 +21,7 @@ import {
   type Transcript,
   type RecordingPreassignment
 } from '../services/database'
-import { getRecordingFiles, deleteRecording as deleteRecordingFile, getRecordingsPath } from '../services/file-storage'
+import { getRecordingFiles, getRecordingsPath } from '../services/file-storage'
 import {
   scoreMeetingCandidates,
   deriveTranscriptTitle,
@@ -51,8 +51,6 @@ import { getQueueItems, addToQueue, updateQueueItem } from '../services/database
 import { getConfig } from '../services/config'
 import {
   GetRecordingByIdSchema,
-  DeleteRecordingSchema,
-  DeleteBatchRecordingsSchema,
   LinkRecordingToMeetingSchema,
   UnlinkRecordingFromMeetingSchema,
   TranscribeRecordingSchema,
@@ -125,77 +123,6 @@ export function registerRecordingHandlers(): void {
     } catch (error) {
       console.error('recordings:getAllWithTranscripts error:', error)
       return []
-    }
-  })
-
-  // Delete a recording
-  ipcMain.handle('recordings:delete', async (_, id: unknown): Promise<boolean> => {
-    try {
-      const result = DeleteRecordingSchema.safeParse({ id })
-      if (!result.success) {
-        console.error('recordings:delete validation error:', result.error)
-        return false
-      }
-
-      const recording = getRecordingById(result.data.id)
-      if (recording && recording.file_path) {
-        const deleted = deleteRecordingFile(recording.file_path)
-        if (deleted) {
-          updateRecordingStatus(result.data.id, 'deleted')
-        }
-        return deleted
-      }
-      return false
-    } catch (error) {
-      console.error('recordings:delete error:', error)
-      return false
-    }
-  })
-
-  // Batch delete recordings (B-LIB-007)
-  ipcMain.handle('recordings:deleteBatch', async (_, ids: unknown): Promise<{
-    success: boolean
-    deleted: number
-    failed: number
-    errors: Array<{ id: string; error: string }>
-  }> => {
-    try {
-      const result = DeleteBatchRecordingsSchema.safeParse({ ids })
-      if (!result.success) {
-        console.error('recordings:deleteBatch validation error:', result.error)
-        return { success: false, deleted: 0, failed: 0, errors: [{ id: '', error: result.error.issues[0]?.message || 'Invalid request' }] }
-      }
-
-      let deleted = 0
-      let failed = 0
-      const errors: Array<{ id: string; error: string }> = []
-
-      for (const id of result.data.ids) {
-        try {
-          const recording = getRecordingById(id)
-          if (recording && recording.file_path) {
-            const wasDeleted = deleteRecordingFile(recording.file_path)
-            if (wasDeleted) {
-              updateRecordingStatus(id, 'deleted')
-              deleted++
-            } else {
-              failed++
-              errors.push({ id, error: 'File deletion failed' })
-            }
-          } else {
-            failed++
-            errors.push({ id, error: 'Recording not found or no file path' })
-          }
-        } catch (e) {
-          failed++
-          errors.push({ id, error: e instanceof Error ? e.message : 'Unknown error' })
-        }
-      }
-
-      return { success: failed === 0, deleted, failed, errors }
-    } catch (error) {
-      console.error('recordings:deleteBatch error:', error)
-      return { success: false, deleted: 0, failed: 0, errors: [{ id: '', error: error instanceof Error ? error.message : 'Unknown error' }] }
     }
   })
 

--- a/apps/electron/electron/main/ipc/validation.ts
+++ b/apps/electron/electron/main/ipc/validation.ts
@@ -119,20 +119,6 @@ export const GetRecordingByIdSchema = z.object({
 })
 
 /**
- * Delete recording request
- */
-export const DeleteRecordingSchema = z.object({
-  id: RecordingIdSchema
-})
-
-/**
- * Batch delete recordings request (B-LIB-007)
- */
-export const DeleteBatchRecordingsSchema = z.object({
-  ids: z.array(z.string().uuid('Each ID must be a valid UUID')).min(1).max(1000)
-})
-
-/**
  * Link recording to meeting request
  */
 export const LinkRecordingToMeetingSchema = z.object({
@@ -256,8 +242,6 @@ export type ExecuteCleanup = z.infer<typeof ExecuteCleanupSchema>
 export type AssignTier = z.infer<typeof AssignTierSchema>
 export type RecordingId = z.infer<typeof RecordingIdSchema>
 export type GetRecordingById = z.infer<typeof GetRecordingByIdSchema>
-export type DeleteRecording = z.infer<typeof DeleteRecordingSchema>
-export type DeleteBatchRecordings = z.infer<typeof DeleteBatchRecordingsSchema>
 export type LinkRecordingToMeeting = z.infer<typeof LinkRecordingToMeetingSchema>
 export type UnlinkRecordingFromMeeting = z.infer<typeof UnlinkRecordingFromMeetingSchema>
 export type TranscribeRecording = z.infer<typeof TranscribeRecordingSchema>

--- a/apps/electron/electron/main/services/__tests__/feature-gate.test.ts
+++ b/apps/electron/electron/main/services/__tests__/feature-gate.test.ts
@@ -95,7 +95,7 @@ describe('gateInvokeHandler', () => {
     )
     // library read on the same prefix → open
     const read = vi.fn().mockResolvedValue([])
-    await expect(gateInvokeHandler('recordings:delete', read)({} as never)).resolves.toEqual([])
+    await expect(gateInvokeHandler('recordings:getAll', read)({} as never)).resolves.toEqual([])
   })
 
   it('reads the flag LIVE — re-enabling a feature unblocks the SAME wrapped handler', async () => {

--- a/apps/electron/electron/preload/index.ts
+++ b/apps/electron/electron/preload/index.ts
@@ -401,13 +401,6 @@ export interface ElectronAPI {
     updateDuration: (id: string, durationSeconds: number) => Promise<{ success: boolean; error?: string }>
     backfillDurations: () => Promise<{ success: boolean; scanned?: number; updated?: number; markedLowValue?: number; error?: string }>
     linkToMeeting: (recordingId: string, meetingId: string, confidence: number, method: string) => Promise<any>
-    delete: (id: string) => Promise<boolean>
-    deleteBatch: (ids: string[]) => Promise<{
-      success: boolean
-      deleted: number
-      failed: number
-      errors: Array<{ id: string; error: string }>
-    }>
     // Privacy source-deletion (v38)
     markPersonal: (id: string, personal: boolean) => Promise<{ success: boolean; personal?: boolean; error?: string }>
     deletionImpact: (id: string) => Promise<{
@@ -1277,8 +1270,6 @@ const electronAPI: ElectronAPI = {
     backfillDurations: () => callIPC('recordings:backfillDurations'),
     linkToMeeting: (recordingId, meetingId, confidence, method) =>
       callIPC('db:link-recording-to-meeting', recordingId, meetingId, confidence, method),
-    delete: (id) => callIPC('recordings:delete', id),
-    deleteBatch: (ids) => callIPC('recordings:deleteBatch', ids),
     markPersonal: (id, personal) => callIPC('recordings:markPersonal', id, personal),
     deletionImpact: (id) => callIPC('recordings:deletionImpact', id),
     deleteCascade: (id, hard) => callIPC('recordings:deleteCascade', id, hard),

--- a/apps/electron/src/shared/__tests__/feature-registry.test.ts
+++ b/apps/electron/src/shared/__tests__/feature-registry.test.ts
@@ -263,7 +263,7 @@ describe('channelFeature (IPC ownership map)', () => {
       'knowledge:getAll',
       'storage:get-info',
       'integrity:run-scan',
-      'recordings:delete', // library reads/deletes stay open
+      'recordings:deleteCascade', // library reads/deletes stay open
       'artifacts:import',
       'waveform:getCache',
       'outputs:generate',


### PR DESCRIPTION
## Summary
- Removes the caller-less legacy `recordings:delete` / `recordings:deleteBatch` IPC handlers left behind after #58 rerouted the last renderer callers (Calendar) to `recordings:deleteCascade`.
- They were a reintroduction hazard: a dishonest permanent-delete path (`deleteRecordingFile` → `unlinkSync` bypassing the recycle bin, keeps all derived data, sets `status='deleted'` with no restore, resolves ids via `getRecordingById` without `resolveRecordingId`) one import away from any new UI.

## Changes
- `recording-handlers.ts`: drop both `ipcMain.handle` registrations; prune the now-unused `deleteRecording as deleteRecordingFile` import (`updateRecordingStatus` stays — still used by `recordings:updateStatus`).
- `preload/index.ts`: drop the `delete:` / `deleteBatch:` bridges and their ElectronAPI type declarations.
- `validation.ts`: drop the now-unused `DeleteRecordingSchema` / `DeleteBatchRecordingsSchema` and their inferred type exports (`DeleteRecordingFileSchema` is a different, live symbol — untouched).
- `recording-handlers.test.ts`: drop the two describe blocks, the registration-list entries, and the orphaned validation/file-storage mocks.
- `feature-gate.test.ts` / `feature-registry.test.ts`: swap the `recordings:delete` specimen for live unowned channels (`recordings:getAll` / `recordings:deleteCascade`) so the tests stop referencing a dead channel; the assertion (unowned → null / not gated) is unchanged.
- `.secrets.baseline`: line-number refresh for the known mock API key in the edited test file (pre-push hook bookkeeping).

Sole remaining soft/hard deletion surface: `recordings:deleteCascade` / `recordings:restore` in `recording-deletion-handlers.ts`. `file-storage.deleteRecording` itself is untouched (still used by `recording-deletion-service.ts` for hard purges).

Renderer callers verified zero: `git grep "recordings\.delete(\|recordings\.deleteBatch("` in `apps/electron/src` → only the two historical comment mentions in `Library.tsx`.

Hunks kept minimal to avoid conflicting with the pending `recordings:getTrash` addition to the same file (claude/f16-f17-value-index-deletion, not yet on beta).

## Testing
- `npm run typecheck` ✓
- `npx vitest run electron/main/ipc/__tests__/recording-handlers.test.ts --project main-db` → 53/53 ✓
- `npx vitest run src/pages/__tests__/Calendar.test.tsx src/pages/__tests__/Library.test.tsx --project renderer` → 23/23 ✓
- `npx vitest run electron/main/services/__tests__/feature-gate.test.ts src/shared/__tests__/feature-registry.test.ts` → 38/38 ✓