### PR TITLE
fix(database): close previous handle on DatabaseEngine re-initialize

### DIFF
--- a/packages/database/src/engine.ts
+++ b/packages/database/src/engine.ts
@@ -553,6 +553,15 @@ export class DatabaseEngine {
   /* --- Initialization / 4-phase boot -------------------------------------- */
 
   async initialize(): Promise<void> {
+    // Re-initialization: release any previous connection before opening a new
+    // one — better-sqlite3 handles are never GC-closed, so overwriting this.bdb
+    // below would strand the old native file handle (open until process exit,
+    // which on Windows also keeps the old .sqlite file undeletable).
+    if (this.bdb) this.closeDatabase()
+    // Per-boot flag (drives the one-time post-migration VACUUM); must not leak
+    // a previous boot's value into this one.
+    this.appliedMigration = false
+
     this.dbPath = this.config.dbPathProvider()
 
     // Safety net: snapshot the existing file BEFORE the first WAL open / migration.

--- a/packages/database/tests/engine.test.ts
+++ b/packages/database/tests/engine.test.ts
@@ -297,6 +297,61 @@ describe('DatabaseEngine', () => {
     engine.closeDatabase()
   })
 
+  it('re-initialize closes the previous handle instead of stranding it', async () => {
+    const first = tempDbPath('reinit-a')
+    const second = tempDbPath('reinit-b')
+    paths.push(first, second)
+    const created: InstanceType<typeof Database>[] = []
+    class TrackingDatabase extends Database {
+      constructor(...args: ConstructorParameters<typeof Database>) {
+        super(...args)
+        created.push(this)
+      }
+    }
+    let currentPath = first
+    const engine = new DatabaseEngine({
+      ...makeEngineConfig({ path: first }),
+      betterSqlite3: TrackingDatabase,
+      dbPathProvider: () => currentPath,
+    })
+
+    await engine.initialize()
+    expect(created).toHaveLength(1)
+    expect(created[0].open).toBe(true)
+
+    currentPath = second
+    await engine.initialize()
+    expect(created).toHaveLength(2)
+    // The first native handle must be closed — not stranded open until process
+    // exit (better-sqlite3 handles are never GC-closed).
+    expect(created[0].open).toBe(false)
+    // Windows refuses to delete a file somebody still holds open — the
+    // stranded-handle symptom that leaked temp DBs from tests. Closed ⇒ deletable.
+    expect(() => rmSync(first, { force: true })).not.toThrow()
+
+    // The engine stays fully usable on the new connection.
+    engine.run('INSERT INTO items (id, name) VALUES (?, ?)', ['a', 'Alpha'])
+    expect(engine.queryAll('SELECT * FROM items')).toHaveLength(1)
+    engine.closeDatabase()
+    expect(created[1].open).toBe(false)
+  })
+
+  it('re-initialize resets per-boot migration state (no repeat VACUUM when nothing migrated)', async () => {
+    const path = tempDbPath('reinit-vacuum')
+    paths.push(path)
+    const engine = new DatabaseEngine(makeEngineConfig({ path, schemaVersion: 2, migrations: { 2: () => {} } }))
+
+    await engine.initialize() // applies v2 — this boot ends in VACUUM, not a checkpoint
+    expect(engine.getPhysicalSaveCount()).toBe(0)
+
+    await engine.initialize() // already at v2 — nothing applied THIS boot
+    // A boot that applied no migration ends in a WAL checkpoint; a stale
+    // appliedMigration=true carried over from the first boot would VACUUM again
+    // (and skip the checkpoint) on every subsequent re-initialize.
+    expect(engine.getPhysicalSaveCount()).toBe(1)
+    engine.closeDatabase()
+  })
+
   it('calls the repairPhase callback during boot', async () => {
     let repaired = false
     const engine = makeEngine('repair', {


### PR DESCRIPTION
## What

`DatabaseEngine.initialize()` now releases any previously-open connection before opening a new one, and resets the per-boot `appliedMigration` flag:

- `if (this.bdb) this.closeDatabase()` at the top of `initialize()` — `closeDatabase()` already checkpoints the WAL (TRUNCATE), closes the native handle, and nulls `bdb`/`shim`.
- `this.appliedMigration = false` per boot — previously a boot that applied a migration left the flag `true` forever, so every subsequent re-initialize re-ran the one-time post-migration VACUUM (and skipped the normal WAL checkpoint).

## Why

A second `initialize()` overwrote `this.bdb` without closing the existing better-sqlite3 connection, stranding the old native file handle until process exit (better-sqlite3 handles are never GC-closed). On Windows that keeps the old `.sqlite` file undeletable — this is the enabler of the stranded-handle pattern that leaked thousands of temp DBs from tests, fixed at the test layer in #62. Harmless at app boot (the only production call site, `apps/electron/electron/main/index.ts`, initializes once), but several test suites re-initialize the same service module and were silently stranding handles.

## Behavior note

A consumer that keeps a `getDatabase()` facade across a re-initialize now fails fast (`The database connection is not open`) instead of silently writing through the stranded old handle. No such consumer exists: production initializes once; the electron `database.test.ts` isolated-lifecycle block re-initializes via fresh module instances (`vi.resetModules()`), where the guard is inert.

## Tests (TDD — both watched failing first)

`packages/database/tests/engine.test.ts`:
- **re-initialize closes the previous handle instead of stranding it** — a tracking `Database` subclass captures every constructed handle; after the second `initialize()` the first handle must be `.open === false` and its file deletable (`rmSync` — the exact Windows leak symptom). Pre-fix, this reproduced the #62 leak in miniature: the suite's own `afterEach` cleanup died with `EPERM` on the still-open temp DB.
- **re-initialize resets per-boot migration state** — a re-init that migrated nothing must end in a WAL checkpoint, not a repeat VACUUM (observed via `getPhysicalSaveCount()`; pre-fix it returned 0).

## Verification

- `packages/database`: 30/30 pass (+ `tsc --noEmit` clean)
- `packages/knowledge-graph`: 114/114 pass
- `apps/electron` full `npx vitest run`: **270/270 files, 3525/3525 tests, exit 0** (includes `database.test.ts`'s isolated-lifecycle block, which deliberately re-initializes)
- An earlier full-suite run hit the two known `transcription.test.ts` load-flakes (their de-flake is open PR #61; that file mocks `../database` entirely, so it never touches this engine) plus 8 suites broken by this worktree's incomplete electron install (missing `dist/`+`path.txt` — repaired from the main checkout). After the env repair everything passes.
