### PR TITLE
test(electron): de-flake five suites still using fixed sleeps

### DIFF
--- a/apps/electron/electron/main/services/__tests__/rag-lru-tokens.test.ts
+++ b/apps/electron/electron/main/services/__tests__/rag-lru-tokens.test.ts
@@ -258,18 +258,19 @@ describe('RAGService cancelRequest', () => {
     // Start the chat but don't await - it will block on the chat-llm generate call
     const chatPromise = rag.chat('active-session', 'test message')
 
-    // Yield to microtask queue so the RAG service reaches the generate call
-    await new Promise(resolve => setTimeout(resolve, 10))
+    try {
+      // Poll until the RAG service reaches the generate call — the abort controller
+      // is registered before generate is invoked, so this proves the session is active.
+      await vi.waitFor(() => expect(mockChatLLMService.generate).toHaveBeenCalled(), { timeout: 15000, interval: 25 })
 
-    // Cancel - the controller should have been set before generate was called
-    const cancelled = rag.cancelRequest('active-session')
-    expect(cancelled).toBe(true)
-
-    // Unblock the mock so the promise can settle
-    resolveChat('cancelled response')
-    await chatPromise
-
-    // Restore mock
-    mockChatLLMService.generate.mockResolvedValue('AI Response')
+      // Cancel - the controller should have been set before generate was called
+      const cancelled = rag.cancelRequest('active-session')
+      expect(cancelled).toBe(true)
+    } finally {
+      // Unblock the mock so the promise can settle, then restore it
+      resolveChat('cancelled response')
+      await chatPromise
+      mockChatLLMService.generate.mockResolvedValue('AI Response')
+    }
   })
 })

--- a/apps/electron/src/hooks/__tests__/useUnifiedRecordings.test.ts
+++ b/apps/electron/src/hooks/__tests__/useUnifiedRecordings.test.ts
@@ -443,7 +443,10 @@ describe('useUnifiedRecordings', () => {
       // recordings.getAll() synchronously inside the initial-load effect body. So once
       // the later-declared recording-watcher effect has subscribed, the load-or-skip
       // decision has already been made — wait for that instead of a fixed sleep.
-      await vi.waitFor(() => expect(window.electronAPI.onRecordingAdded).toHaveBeenCalled(), { timeout: 15000, interval: 25 })
+      await vi.waitFor(
+        () => expect(window.electronAPI.onRecordingAdded).toHaveBeenCalled(),
+        { timeout: 15000, interval: 25 }
+      )
 
       // Should NOT have called any API because data is already loaded
       expect(window.electronAPI.recordings.getAll).not.toHaveBeenCalled()

--- a/apps/electron/src/hooks/__tests__/useUnifiedRecordings.test.ts
+++ b/apps/electron/src/hooks/__tests__/useUnifiedRecordings.test.ts
@@ -62,7 +62,7 @@ describe('useUnifiedRecordings', () => {
       setUnifiedRecordingsError: vi.fn(),
       markUnifiedRecordingsLoaded: vi.fn()
     }
-    // @ts-ignore
+    // @ts-ignore - useAppStore is vi-mocked, so mockImplementation exists at runtime
     useAppStore.mockImplementation((selector: any) => selector(storeState))
   })
 
@@ -136,9 +136,9 @@ describe('useUnifiedRecordings', () => {
         status: 'ready'
       }]
 
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.recordings.getAll.mockResolvedValue(mockRecs)
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.knowledge.getAll.mockResolvedValue(mockCaptures)
 
       renderHook(() => useUnifiedRecordings())
@@ -164,9 +164,9 @@ describe('useUnifiedRecordings', () => {
         status: 'complete',
         date_recorded: '2025-01-01T10:00:00Z'
       }]
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.recordings.getAll.mockResolvedValue(mockRecs)
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.knowledge.getAll.mockResolvedValue([])
 
       renderHook(() => useUnifiedRecordings())
@@ -275,7 +275,7 @@ describe('useUnifiedRecordings', () => {
 
   describe('error handling', () => {
     it('sets error state when recordings fetch fails', async () => {
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.recordings.getAll.mockRejectedValue(new Error('Database error'))
 
       renderHook(() => useUnifiedRecordings())
@@ -286,7 +286,7 @@ describe('useUnifiedRecordings', () => {
     })
 
     it('sets error state with generic message for non-Error exceptions', async () => {
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.recordings.getAll.mockRejectedValue('string error')
 
       renderHook(() => useUnifiedRecordings())
@@ -297,7 +297,7 @@ describe('useUnifiedRecordings', () => {
     })
 
     it('decrements loading counter on error', async () => {
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.recordings.getAll.mockRejectedValue(new Error('Fetch failed'))
 
       renderHook(() => useUnifiedRecordings())
@@ -323,7 +323,7 @@ describe('useUnifiedRecordings', () => {
   describe('electronAPI guard - crash prevention', () => {
     it('does not crash when window.electronAPI is undefined', () => {
       const savedAPI = window.electronAPI
-      // @ts-ignore
+      // @ts-ignore - simulate a non-Electron environment
       delete window.electronAPI
 
       try {
@@ -337,7 +337,7 @@ describe('useUnifiedRecordings', () => {
 
     it('returns empty recordings when electronAPI is undefined', async () => {
       const savedAPI = window.electronAPI
-      // @ts-ignore
+      // @ts-ignore - simulate a non-Electron environment
       delete window.electronAPI
 
       try {
@@ -353,7 +353,7 @@ describe('useUnifiedRecordings', () => {
 
     it('does not crash when electronAPI.onRecordingAdded is undefined', () => {
       const savedAPI = window.electronAPI
-      // @ts-ignore
+      // @ts-ignore - install a deliberately partial electronAPI for this case
       window.electronAPI = { recordings: { getAll: vi.fn().mockResolvedValue([]) } }
 
       try {
@@ -367,7 +367,7 @@ describe('useUnifiedRecordings', () => {
 
     it('does not crash when electronAPI.recordings is undefined', () => {
       const savedAPI = window.electronAPI
-      // @ts-ignore
+      // @ts-ignore - install a deliberately partial electronAPI for this case
       window.electronAPI = { onRecordingAdded: vi.fn(() => vi.fn()) }
 
       try {
@@ -439,8 +439,11 @@ describe('useUnifiedRecordings', () => {
 
       renderHook(() => useUnifiedRecordings())
 
-      // Wait a tick for effects to run
-      await new Promise(resolve => setTimeout(resolve, 50))
+      // Mount effects run in declaration order, and a wrongly-triggered load calls
+      // recordings.getAll() synchronously inside the initial-load effect body. So once
+      // the later-declared recording-watcher effect has subscribed, the load-or-skip
+      // decision has already been made — wait for that instead of a fixed sleep.
+      await vi.waitFor(() => expect(window.electronAPI.onRecordingAdded).toHaveBeenCalled(), { timeout: 15000, interval: 25 })
 
       // Should NOT have called any API because data is already loaded
       expect(window.electronAPI.recordings.getAll).not.toHaveBeenCalled()
@@ -460,7 +463,7 @@ describe('useUnifiedRecordings', () => {
 
     it('returns unsubscribe function from onRecordingAdded', () => {
       const unsubscribeFn = vi.fn()
-      // @ts-ignore
+      // @ts-ignore - electronAPI members are vi.fn mocks in tests
       window.electronAPI.onRecordingAdded.mockReturnValue(unsubscribeFn)
 
       const { unmount } = renderHook(() => useUnifiedRecordings())

--- a/apps/electron/src/services/__tests__/hidock-device-autoconnect.test.ts
+++ b/apps/electron/src/services/__tests__/hidock-device-autoconnect.test.ts
@@ -299,8 +299,10 @@ describe('HiDockDeviceService - auto-connect contract (real service)', () => {
     const service = new HiDockDeviceService()
     const serviceAny = service as any
 
-    // Wait for config to load (config says autoConnect: true)
-    await new Promise(resolve => setTimeout(resolve, 50))
+    // Wait for config to load (config says autoConnect: true); the service flips
+    // configLoaded once loadAutoConnectConfig() settles, so poll that instead of
+    // racing the async load with a fixed sleep.
+    await vi.waitUntil(() => serviceAny.configLoaded === true, { timeout: 15000, interval: 25 })
 
     service.disableAutoConnect()
 

--- a/apps/electron/src/services/__tests__/hidock-device.test.ts
+++ b/apps/electron/src/services/__tests__/hidock-device.test.ts
@@ -3666,18 +3666,24 @@ describe('HiDockDeviceService - persistCacheToStorage error path', () => {
       { filename: 'test.wav', size: 1024, duration: 60, dateCreated: new Date() }
     ]
 
-    serviceAny.persistCacheToStorage()
+    try {
+      serviceAny.persistCacheToStorage()
 
-    // Wait for the catch to fire
-    await new Promise(resolve => setTimeout(resolve, 10))
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to persist cache'),
-      expect.any(Error)
-    )
-
-    warnSpy.mockClear()
-    delete (globalThis as any).window
+      // persistCacheToStorage is fire-and-forget; poll until the saveAll
+      // rejection reaches its catch instead of racing it with a fixed sleep.
+      await vi.waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to persist cache'),
+          expect.any(Error)
+        )
+      }, { timeout: 15000, interval: 25 })
+    } finally {
+      // mockClear, never mockRestore — the spy IS the file-lifetime console
+      // silencer, and restoring would reinstall the real console.warn (see the
+      // silencer note at the top of this file).
+      warnSpy.mockClear()
+      delete (globalThis as any).window
+    }
   })
 
   it('should use current date when dateCreated is missing', () => {

--- a/apps/electron/src/services/__tests__/jensen.test.ts
+++ b/apps/electron/src/services/__tests__/jensen.test.ts
@@ -416,10 +416,9 @@ describe('JensenDevice', () => {
       device.onconnect = onconnectSpy
 
       await device.connect()
-      // onconnect is deferred via setTimeout(300) to give the device firmware
-      // time to stabilize after USB interface is claimed before sending commands.
-      await new Promise(resolve => setTimeout(resolve, 350))
-      expect(onconnectSpy).toHaveBeenCalledTimes(1)
+      // onconnect fires from a setTimeout(0) deferral after connect() resolves,
+      // so poll for the callback instead of racing it with a fixed sleep.
+      await vi.waitFor(() => expect(onconnectSpy).toHaveBeenCalledTimes(1), { timeout: 15000, interval: 25 })
     })
 
     it('resets sequence ID on connect', async () => {


### PR DESCRIPTION
## Summary

Follow-up to the transcription.test.ts de-flake (#61): five more `apps/electron` suites used `await new Promise(resolve => setTimeout(resolve, N))` followed by assertions, which races real async work (first-time dynamic imports, IPC promise chains) under full-suite CPU contention — vitest transform latency is external to the worker while the wall-clock timer keeps ticking.

Each sleep was replaced with `vi.waitFor` / `vi.waitUntil` polling the condition it actually waited for (15s timeout, 25ms interval):

| File | Sleep | Actually waits for | Replacement |
|---|---|---|---|
| `hidock-device-autoconnect.test.ts` | 50ms | constructor's async config load | `waitUntil(() => serviceAny.configLoaded)` |
| `jensen.test.ts` | 350ms | `onconnect` deferred via `setTimeout(0)` (comment claiming 300ms was stale) | `waitFor(onconnectSpy called once)` |
| `hidock-device.test.ts` | 10ms | fire-and-forget `persistCacheToStorage` rejection reaching its catch | `waitFor(warnSpy called)`; cleanup in `finally` (kept as `mockClear()` per the file-lifetime console-silencer rule from 7c4007a4) |
| `useUnifiedRecordings.test.ts` | 50ms | negative assertion (`getAll` NOT called) — can't waitFor a negative | wait for the later-declared recording-watcher subscription (mount effects run in declaration order; a wrong load calls `getAll` synchronously in the earlier effect), then assert the negative |
| `rag-lru-tokens.test.ts` | 10ms | `rag.chat` reaching the deliberately blocked `generate` call | `waitFor(generate called)`; blocker resolution + mock restore in `finally` so a failure can't leak a never-resolving `generate` into later tests |

Also adds the missing `@ts-ignore` descriptions eslint flagged in `useUnifiedRecordings.test.ts` (13 warnings → 0).

Replaces #65, which was accidentally based on the `main` lineage and conflicted with this base; these are the same two commits cherry-picked onto `beta/meeting-intelligence` (one conflict resolved in `hidock-device.test.ts` to preserve the console-silencer `mockClear()` semantics).

## Verification

- On the main-based branch: each file passed **10x in isolation** with all five loops in parallel (deliberate CPU contention); full suite 217 files / 2898 tests green; typecheck + eslint clean; reviewed by a code-review agent (1 finding, fixed)
- Re-verified on this beta-based branch: per-file runs + full suite + typecheck (results in PR comments if CI doesn't cover them)