### PR TITLE
test(electron): give the 520-row pixel-rag eligibility test a 20s budget

### DIFF
--- a/apps/electron/electron/main/services/__tests__/pixel-rag.test.ts
+++ b/apps/electron/electron/main/services/__tests__/pixel-rag.test.ts
@@ -236,7 +236,9 @@ describe('F5 PixelRAG — image captures as RAG sources', () => {
 
   const fixtures: { healthyIds: string[]; poisonIds: string[] } = { healthyIds: [], poisonIds: [] }
 
-  it('poison captures cool down after a failed attempt — older healthy captures still progress, vision bounded', async () => {
+  it(
+    'poison captures cool down after a failed attempt — older healthy captures still progress, vision bounded',
+    async () => {
     // Healthy OLDER captures: imported with no key → no vision, no text, no state.
     h.geminiKey = ''
     for (const tag of ['h1', 'h2']) {
@@ -365,7 +367,13 @@ describe('F5 PixelRAG — image captures as RAG sources', () => {
     expect(h.visionCalls).toBe(0)
   })
 
-  it('SQL-side eligibility: 500+ terminal rows ahead cannot hide an older eligible capture', async () => {
+  // 520 sequential INSERTs blow the default 5s testTimeout on starved CI runners
+  // (failed the beta push run of #66 at exactly this line) — same runner-speed
+  // class as the #61/#66 margins, so give the test the established 20s budget.
+  it(
+    'SQL-side eligibility: 500+ terminal rows ahead cannot hide an older eligible capture',
+    { timeout: 20000 },
+    async () => {
     // 520 NEWER terminal rows — more than any scan window. Inserted directly
     // (they need no files: SQL eligibility must exclude them before retrieval).
     const terminalMeta = JSON.stringify({


### PR DESCRIPTION
## Summary

The beta push run of #66 ([run 29386235509](https://github.com/sgeraldes/hidock-next/actions/runs/29386235509)) failed on exactly one test: `pixel-rag.test.ts` › *SQL-side eligibility: 500+ terminal rows ahead cannot hide an older eligible capture* — **Test timed out in 5000ms**; the other 3514 tests passed.

That test performs 520 sequential `INSERT`s before its scan, and on a starved windows-latest runner that blows the default 5s `testTimeout`. The #66/514036c4 margins raised `hookTimeout` for DB-init hooks, but this is the *test*-timeout knob on a heavy test body — same runner-speed class, different setting.

Fix: the established `it(name, { timeout: 20000 }, fn)` budget from #61, plus wrapping the file's one pre-existing >120-char test title to the line-length convention.

## Verification

- `pixel-rag.test.ts` passes 6x locally (5x loop + single run), 10/10 tests
- eslint clean, no >120-char lines remain in the file