### PR TITLE
test(electron): type activity-log results in hidock-device test

### DIFF
--- a/apps/electron/src/services/__tests__/hidock-device.test.ts
+++ b/apps/electron/src/services/__tests__/hidock-device.test.ts
@@ -724,7 +724,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
 
   it('should return empty activity log initially', () => {
     const service = new HiDockDeviceService()
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     // Should only have initialization log
     expect(logs.length).toBe(1)
@@ -738,7 +738,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
     serviceAny.logActivity('info', 'Test log 1')
     serviceAny.logActivity('success', 'Test log 2')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     expect(logs.length).toBe(3) // initialization + 2 test logs
 
     const testLogs = logs.filter(log => log.message.startsWith('Test log'))
@@ -755,7 +755,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
 
     serviceAny.logActivity('error', 'Error occurred', 'Stack trace here')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.message === 'Error occurred')
 
     expect(errorLog).toBeDefined()
@@ -775,7 +775,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
 
     service.clearActivityLog()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     expect(logs.length).toBe(0)
   })
 
@@ -787,7 +787,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
     serviceAny.logActivity('info', 'Second log')
     serviceAny.logActivity('info', 'Third log')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const testLogs = logs.filter(log => log.message.includes('log'))
 
     expect(testLogs[0].timestamp.getTime()).toBeLessThanOrEqual(testLogs[1].timestamp.getTime())
@@ -805,7 +805,7 @@ describe('HiDockDeviceService - Activity Log Management', () => {
     serviceAny.logActivity('usb-in', 'USB in log')
     serviceAny.logActivity('warning', 'Warning log')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     expect(logs.find(log => log.type === 'error')).toBeDefined()
     expect(logs.find(log => log.type === 'success')).toBeDefined()
     expect(logs.find(log => log.type === 'info')).toBeDefined()
@@ -1169,7 +1169,7 @@ describe('HiDockDeviceService - Constructor and Initialization', () => {
 
   it('should log initialization activity', () => {
     const service = new HiDockDeviceService()
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     const initLog = logs.find(log => log.message === 'Device service initialized')
     expect(initLog).toBeDefined()
@@ -1779,7 +1779,7 @@ describe('HiDockDeviceService - Public Log Method', () => {
 
     service.log('info', 'Public log message')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const publicLog = logs.find(log => log.message === 'Public log message')
 
     expect(publicLog).toBeDefined()
@@ -1791,7 +1791,7 @@ describe('HiDockDeviceService - Public Log Method', () => {
 
     service.log('error', 'Public error', 'Error details')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.message === 'Public error')
 
     expect(errorLog).toBeDefined()
@@ -1809,7 +1809,7 @@ describe('HiDockDeviceService - Public Log Method', () => {
     service.log('usb-out', 'USB out message')
     service.log('usb-in', 'USB in message')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     expect(logs.find(log => log.message === 'Info message')).toBeDefined()
     expect(logs.find(log => log.message === 'Success message')).toBeDefined()
@@ -1858,7 +1858,7 @@ describe('HiDockDeviceService - Activity Log Max Entries', () => {
       service.log('info', `Log ${i}`)
     }
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     // Should not exceed max entries
     expect(logs.length).toBeLessThanOrEqual(MAX_ACTIVITY_LOG_ENTRIES)
@@ -1872,7 +1872,7 @@ describe('HiDockDeviceService - Activity Log Max Entries', () => {
       service.log('info', `Log ${i}`)
     }
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     // Should contain the most recent logs
     const lastLog = logs[logs.length - 1]
@@ -1887,7 +1887,7 @@ describe('HiDockDeviceService - Activity Log Max Entries', () => {
       service.log('info', `Log ${i}`)
     }
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
 
     // Should not contain the oldest logs
     const hasOldLog = logs.some(log => log.message === 'Log 0')
@@ -1985,8 +1985,8 @@ describe('HiDockDeviceService - Activity Log Copy', () => {
 
     service.log('info', 'Test log')
 
-    const log1 = service.getActivityLog()
-    const log2 = service.getActivityLog()
+    const log1: ActivityLogEntry[] = service.getActivityLog()
+    const log2: ActivityLogEntry[] = service.getActivityLog()
 
     // Should be different array references
     expect(log1).not.toBe(log2)
@@ -2000,7 +2000,7 @@ describe('HiDockDeviceService - Activity Log Copy', () => {
 
     service.log('info', 'Test log')
 
-    const log = service.getActivityLog()
+    const log: ActivityLogEntry[] = service.getActivityLog()
     const originalLength = log.length
 
     log.push({
@@ -2010,7 +2010,7 @@ describe('HiDockDeviceService - Activity Log Copy', () => {
     })
 
     // Internal log should not change
-    const newLog = service.getActivityLog()
+    const newLog: ActivityLogEntry[] = service.getActivityLog()
     expect(newLog.length).toBe(originalLength)
   })
 })
@@ -2120,7 +2120,7 @@ describe('HiDockDeviceService - Refresh Device Info', () => {
 
     await service.refreshDeviceInfo()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const usbOutLog = logs.find(log => log.type === 'usb-out' && log.message === 'CMD: Get Device Info')
     const usbInLog = logs.find(log => log.type === 'usb-in' && log.message === 'Device Info Received')
 
@@ -2139,7 +2139,7 @@ describe('HiDockDeviceService - Refresh Device Info', () => {
 
     await service.refreshDeviceInfo()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.type === 'error' && log.message === 'Failed to get device info')
 
     expect(errorLog).toBeDefined()
@@ -2325,7 +2325,7 @@ describe('HiDockDeviceService - Refresh Storage Info', () => {
 
     await service.refreshStorageInfo()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.type === 'error' && log.message === 'Failed to get card info')
 
     expect(errorLog).toBeDefined()
@@ -2446,7 +2446,7 @@ describe('HiDockDeviceService - Refresh Settings', () => {
 
     await service.refreshSettings()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.type === 'error' && log.message === 'Failed to get settings')
 
     expect(errorLog).toBeDefined()
@@ -2552,7 +2552,7 @@ describe('HiDockDeviceService - Sync Time', () => {
 
     await service.syncTime()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const successLog = logs.find(log => log.type === 'success' && log.message === 'Time synced successfully')
 
     expect(successLog).toBeDefined()
@@ -2569,7 +2569,7 @@ describe('HiDockDeviceService - Sync Time', () => {
 
     await service.syncTime()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.type === 'error' && log.message === 'Failed to sync time')
 
     expect(errorLog).toBeDefined()
@@ -2676,7 +2676,7 @@ describe('HiDockDeviceService - Get Recording Count', () => {
 
     await service.getRecordingCount()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const usbOutLog = logs.find(log => log.type === 'usb-out' && log.message === 'CMD: Get File Count')
     const usbInLog = logs.find(log => log.type === 'usb-in' && log.message === 'File Count Received')
 
@@ -2758,7 +2758,7 @@ describe('HiDockDeviceService - List Recordings Not Connected', () => {
 
     await service.listRecordings()
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.message === 'Cannot list files')
 
     expect(errorLog).toBeDefined()
@@ -3136,7 +3136,7 @@ describe('HiDockDeviceService - Delete Recording', () => {
 
     await service.deleteRecording('test.wav')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const successLog = logs.find(log => log.type === 'success' && log.message === 'File deleted')
 
     expect(successLog).toBeDefined()
@@ -3173,7 +3173,7 @@ describe('HiDockDeviceService - Delete Recording', () => {
 
     await service.deleteRecording('test.wav')
 
-    const logs = service.getActivityLog()
+    const logs: ActivityLogEntry[] = service.getActivityLog()
     const errorLog = logs.find(log => log.type === 'error' && log.message === 'Failed to delete file')
 
     expect(errorLog).toBeDefined()


### PR DESCRIPTION
## Summary
Removes ~27 hint-level TS7044 diagnostics ("Parameter 'log' implicitly has an 'any' type") reported by the TypeScript language server on callback parameters in `apps/electron/src/services/__tests__/hidock-device.test.ts`.

## Root cause
The suite loads `HiDockDeviceService` via a dynamic import typed as `any` (`let HiDockDeviceService: any`), so `service.getActivityLog()` returns an untyped array and every `logs.filter(log => ...)` / `logs.find(log => ...)` callback parameter is an implicit `any`.

## Fix
Annotate each `getActivityLog()` result with the existing `ActivityLogEntry` type, which the file already imports (`import type { ActivityLogEntry } from '../hidock-device'`) and already uses for the `receivedLogs` listener arrays — same idiom, applied to the remaining 27 declarations (23× `logs`, plus `log1`/`log2`/`log`/`newLog`). Type-only change; zero test-behavior changes (diff is 27 modified lines, all annotations).

## Verification
- `npx vitest run src/services/__tests__/hidock-device.test.ts` → **186/186 passed**
- `npm run typecheck` (node + web; `tsconfig.web.json` includes `src/**/*`, so the test file is tsc-validated) → exit 0
- `npx eslint src/services/__tests__/hidock-device.test.ts` → exit 0
- LSP hover on a previously-flagged callback param now infers `(parameter) log: ActivityLogEntry`