### PR TITLE
test(electron): silence jsdom canvas noise on main — backport #59 stubs

### DIFF
--- a/apps/electron/src/__tests__/accessibility/library-a11y.test.tsx
+++ b/apps/electron/src/__tests__/accessibility/library-a11y.test.tsx
@@ -394,6 +394,11 @@ describe('Library Accessibility', () => {
   })
 
   it('should have no color contrast violations', async () => {
+    // NOTE: jsdom has no paint/layout, so axe can only evaluate the computable
+    // subset of color-contrast here (inline/stylesheet colors; text metrics and
+    // pseudo-element backgrounds are stubbed — see src/test/setup.ts). Treat a
+    // pass as "no violations axe could compute", not full WCAG 1.4.3 coverage;
+    // authoritative contrast verification needs a real browser (E2E).
     const { container } = render(
       <MemoryRouter>
         <Library />

--- a/apps/electron/src/test/setup.ts
+++ b/apps/electron/src/test/setup.ts
@@ -54,6 +54,95 @@ if (typeof window !== 'undefined') {
   // Mock scrollIntoView
   window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
+  // jsdom ships no canvas implementation: HTMLCanvasElement#getContext logs
+  // "Not implemented: HTMLCanvasElement's getContext() method: without installing
+  // the canvas npm package" to stderr and returns null, so any component that
+  // draws on mount (WaveformCanvas whenever a test feeds it real audioData)
+  // spams the run output. Return a minimal per-canvas 2D stub instead of
+  // installing the native `canvas` package. Tests that assert on drawing
+  // (WaveformCanvas.test.tsx) vi.spyOn(getContext) over this stub and are
+  // unaffected. Non-'2d' requests (e.g. webgl) return null, silently.
+  // measureText → width 0 also keeps axe-core's icon-ligature probe (the other
+  // getContext caller, via color-contrast in library-a11y.test.tsx) on its
+  // cheap early-return path instead of rasterizing glyphs we can't produce.
+  const context2dByCanvas = new WeakMap<HTMLCanvasElement, CanvasRenderingContext2D>()
+
+  const makeContext2d = (canvas: HTMLCanvasElement): CanvasRenderingContext2D =>
+    ({
+      canvas,
+      fillStyle: '#000',
+      strokeStyle: '#000',
+      lineWidth: 1,
+      globalAlpha: 1,
+      font: '',
+      textAlign: 'left',
+      textBaseline: 'top',
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      clip: vi.fn(),
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      strokeRect: vi.fn(),
+      fillText: vi.fn(),
+      strokeText: vi.fn(),
+      measureText: vi.fn(() => ({ width: 0 })),
+      getImageData: vi.fn((_x: number, _y: number, w: number, h: number) => ({
+        width: w,
+        height: h,
+        data: new Uint8ClampedArray(Math.max(0, Math.floor(w)) * Math.max(0, Math.floor(h)) * 4)
+      })),
+      putImageData: vi.fn(),
+      createImageData: vi.fn((w: number, h: number) => ({
+        width: w,
+        height: h,
+        data: new Uint8ClampedArray(Math.max(0, Math.floor(w)) * Math.max(0, Math.floor(h)) * 4)
+      })),
+      drawImage: vi.fn(),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createPattern: vi.fn(() => null),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      rotate: vi.fn(),
+      setTransform: vi.fn(),
+      resetTransform: vi.fn(),
+      setLineDash: vi.fn(),
+      getLineDash: vi.fn(() => [])
+    }) as unknown as CanvasRenderingContext2D
+
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextId: string
+  ): CanvasRenderingContext2D | null {
+    if (contextId !== '2d') return null
+    let ctx = context2dByCanvas.get(this)
+    if (!ctx) {
+      ctx = makeContext2d(this)
+      context2dByCanvas.set(this, ctx)
+    }
+    return ctx
+  } as typeof HTMLCanvasElement.prototype.getContext
+
+  // jsdom answers getComputedStyle(el, '::before') by IGNORING the pseudo
+  // argument — it logs "Not implemented: Window's getComputedStyle() method:
+  // with pseudo-elements" and then returns the element's own computed style.
+  // axe-core's color-contrast rule probes ::before/::after backgrounds on every
+  // run (dozens of lines across the a11y suite), so drop the pseudo argument up
+  // front: the return value is exactly what jsdom would have produced, minus
+  // the stderr noise. Real pseudo-element styles still can't be asserted in
+  // jsdom — see the note on the color-contrast test in library-a11y.test.tsx.
+  const realGetComputedStyle = window.getComputedStyle.bind(window)
+  window.getComputedStyle = ((elt: Element) =>
+    realGetComputedStyle(elt)) as typeof window.getComputedStyle
+
   // Pointer-capture APIs jsdom doesn't implement — Radix popper components
   // (DropdownMenu, Select, Popover) call these when opening via pointer.
   if (!window.HTMLElement.prototype.hasPointerCapture) {


### PR DESCRIPTION
## Problem

Every full `npx vitest run` in `apps/electron` on a **main-based** tree prints 4 unattributed stderr lines (all tests passing):

```
Not implemented: HTMLCanvasElement's getContext() method: without installing the canvas npm package
```

These were recently observed and initially believed to be a leftover gap on `beta/meeting-intelligence` after PR #59. Instrumented reproduction shows that is not the case.

## Investigation (instrumented, not eyeballed)

A temporary stack-logging wrapper inside `node_modules/jsdom/lib/jsdom/browser/not-implemented.js` (the single funnel every jsdom realm goes through) was used to attribute every call across **full** suite runs in clean provisioned worktrees:

| Tree | Result |
|---|---|
| `beta` tip (16acec1e) | 3515/3515 pass, **0** canvas lines, **0** calls reach jsdom |
| `beta` at ebbabce0 (observation-day commit) | 3519/3519 pass, **0** lines, **0** calls |
| **`main` (d5ab75f8)** | 2898/2898 pass, **4** stderr lines, 4 stacks captured |

The 4 captured stacks on main:

| # | Caller | Path |
|---|---|---|
| 1–3 | axe-core `colorContrastMatches` → `_isIconLigature` → `canvas.getContext('2d')` | `src/__tests__/accessibility/library-a11y.test.tsx:217/243/403` |
| 4 | `WaveformCanvas` draw-on-mount (`WaveformCanvas.tsx:119`) | `WaveformPlayer.test.tsx:154` (feeds real `audioData`) |

This is byte-for-byte the same attribution PR #59 documented. **Beta already has the fix; main never received it** — the "4 unattributed lines" only reproduce on main-based trees (e.g. session worktrees branched from main).

## Fix

Verbatim backport of #59's two files (`git diff ebbabce0^1 ebbabce0` applies cleanly; bases were byte-identical):

- `src/test/setup.ts` (+89): per-canvas 2D context stub (WeakMap-cached), pseudo-element-argument drop for `getComputedStyle`, pointer-capture no-ops
- `src/__tests__/accessibility/library-a11y.test.tsx` (+5): the NOTE documenting jsdom's contrast-coverage limits

Both files are now **byte-identical to beta tip**, so the next beta→main promotion has zero drift on them.

## Routing note

QA-first routing is satisfied: this content was merged and verified on `beta/meeting-intelligence` via PR #59 (ebbabce0). This PR is the reverse-direction twin of #66 (which backported #60 main→beta), keeping the two lines in sync.

## Evidence (this branch)

- Before: full run 2898/2898 pass, exit 0, **4** canvas stderr lines (stack log: 4 entries)
- After: full run 2898/2898 pass, exit 0, **stderr byte-empty**, instrumented funnel count **0**
- Final pristine re-run (instrumentation removed): 2898/2898 pass, **0** lines
- `npm run typecheck` clean; `npx eslint` on both changed files clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved accessibility test setup for more reliable color-contrast checks.
  * Added browser API stubs to reduce test noise and better support simulated canvas and style calculations.
  * Documented testing limitations in the simulated browser environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->