### PR TITLE
fix(electron): make check:native protect the vitest DB binding

### DIFF
--- a/apps/electron/scripts/dev/check-native.mjs
+++ b/apps/electron/scripts/dev/check-native.mjs
@@ -9,24 +9,38 @@
  * gets an Electron-ABI binary via `electron-builder install-app-deps`
  * (postinstall). This script bridges the two:
  *
- *   1. back up the current (Node-ABI) binary,
+ *   1. back up the current binaries — BOTH copies: the app-local one and the
+ *      packages/database one (the rebuild step resolves better-sqlite3 through
+ *      the @hidock/database link and can rebuild that copy too),
  *   2. rebuild better-sqlite3 for Electron's ABI (@electron/rebuild),
  *   3. load it inside Electron's own runtime and exercise a WAL round-trip,
- *   4. restore the Node-ABI binary so the Vitest suites keep passing.
+ *   4. restore the backed-up binaries so the Vitest suites keep passing,
+ *   5. verify the packages/database copy still loads under the CURRENT Node —
+ *      that copy is what the main-db vitest project actually requires (the
+ *      dual-ABI shim in src/test/setup-db.ts redirects there); leaving it
+ *      Electron-ABI fails every DB-backed test file with a
+ *      NODE_MODULE_VERSION error.
  *
- * Exit code 0 = better-sqlite3 is Electron-ABI-loadable. Non-zero = it is not.
+ * Exit code 0 = better-sqlite3 is Electron-ABI-loadable AND the vitest binding
+ * contract holds. Non-zero = one of the two is broken.
  */
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, copyFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 
 const require = createRequire(import.meta.url)
 const appDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const binaryPath = join(appDir, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node')
-const backupPath = `${binaryPath}.node-abi.bak`
+const packagesDbDir = join(appDir, '..', '..', 'packages', 'database')
+// Every better_sqlite3.node the rebuild step can reach. The packages/database
+// copy is the one the vitest main-db project loads (src/test/setup-db.ts).
+const binaryPaths = [
+  join(appDir, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+  join(packagesDbDir, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node'),
+]
+const backupOf = (p) => `${p}.node-abi.bak`
 // Probe lives inside the app dir so `require('better-sqlite3')` resolves against
 // the app's node_modules (require resolves relative to the script's location).
 const probePath = join(appDir, '.check-native-probe.cjs')
@@ -52,17 +66,50 @@ function runElectron(bin, args, opts = {}) {
 let restored = false
 function restoreNodeAbi() {
   if (restored) return
-  if (existsSync(backupPath)) {
-    copyFileSync(backupPath, binaryPath)
-    rmSync(backupPath, { force: true })
-    console.log('[check-native] Restored Node-ABI binary (Vitest suites keep working).')
+  for (const binaryPath of binaryPaths) {
+    const backupPath = backupOf(binaryPath)
+    if (existsSync(backupPath)) {
+      copyFileSync(backupPath, binaryPath)
+      rmSync(backupPath, { force: true })
+      console.log(`[check-native] Restored pre-check binary: ${relative(appDir, binaryPath)}`)
+    }
   }
   rmSync(probePath, { force: true })
   restored = true
 }
 
+/**
+ * The binding the vitest main-db project loads is NOT the app-local copy — the
+ * setup-db.ts shim redirects require('better-sqlite3') to the copy inside
+ * packages/database, which must stay built for the CURRENT Node ABI. Probe it
+ * in a child process (a failed in-process require of a wrong-ABI binary cannot
+ * be retried cleanly) and fail loudly with the repair command if it is broken.
+ */
+function verifyVitestBindingContract() {
+  if (!existsSync(join(packagesDbDir, 'node_modules', 'better-sqlite3'))) {
+    console.log('[check-native] packages/database better-sqlite3 not installed; skipping vitest-contract check.')
+    return
+  }
+  const probe =
+    "const D = require('better-sqlite3');" +
+    "const db = new D(':memory:'); db.exec('CREATE TABLE t (x INTEGER)'); db.close();" +
+    "console.log('[check-native] packages/database better-sqlite3 OK under Node (NODE_MODULE_VERSION ' + process.versions.modules + ') — vitest contract holds.');"
+  try {
+    execFileSync(process.execPath, ['-e', probe], { cwd: packagesDbDir, stdio: 'inherit', shell: false })
+  } catch {
+    console.error(
+      '[check-native] FAIL: the packages/database better-sqlite3 binding does not load under the current Node — ' +
+        'every DB-backed vitest file will fail with a NODE_MODULE_VERSION error. ' +
+        'Repair with: (cd packages/database && npm rebuild better-sqlite3)'
+    )
+    process.exit(1)
+  }
+}
+
 try {
-  if (existsSync(binaryPath)) copyFileSync(binaryPath, backupPath)
+  for (const binaryPath of binaryPaths) {
+    if (existsSync(binaryPath)) copyFileSync(binaryPath, backupOf(binaryPath))
+  }
 
   console.log('[check-native] Rebuilding better-sqlite3 for the Electron ABI...')
   runShell('npx', ['electron-rebuild', '-f', '-w', 'better-sqlite3'])
@@ -87,6 +134,7 @@ try {
   runElectron(electronBinary(), [probePath], { env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' } })
 
   restoreNodeAbi()
+  verifyVitestBindingContract()
   console.log('[check-native] PASS')
   process.exit(0)
 } catch (err) {


### PR DESCRIPTION
## Summary

`npm run check:native` rebuilds better-sqlite3 for Electron's ABI to prove the packaged-app side works, but it only backed up / restored the **app-local** binary. The rebuild step can also reach the **packages/database** copy (resolved through the `@hidock/database` link) — the copy the `main-db` vitest project actually loads via the `src/test/setup-db.ts` dual-ABI shim — silently leaving it Electron-ABI.

Net effect, observed live in a fresh worktree today: `check:native` printed `PASS`, then the very next `npx vitest run` produced **141 phantom failures across 19 DB-backed files**, all rooted in one `NODE_MODULE_VERSION 140 vs 147` bindings error. The tool whose job is to catch native-binding breakage was passing while (and partly because) it broke the other half of the contract.

## Changes (scripts/dev/check-native.mjs only)

- Back up and restore **both** `better_sqlite3.node` copies (app-local + packages/database) around the electron-rebuild. Restoring an untouched file is a harmless no-op.
- New step 5: after restore, probe the packages/database copy under the **current Node** in a child process; if it does not load, fail with exit 1 and the exact repair command (`cd packages/database && npm rebuild better-sqlite3`).
- Honest logging: per-file restore lines instead of an unconditional "Restored Node-ABI binary" claim (the old message printed even when the backup it restored was not Node-ABI).

## Test plan (all exercised on Windows, Node 26 / npm 11.18)

- **Pre-broken env** (packages copy deliberately Electron-ABI): `check:native` → `FAIL` + repair command, exit 1 ✔
- **Healthy env**: `check:native` → Electron probe OK (ABI 140), both binaries restored, packages copy verified under Node (ABI 147), `PASS`, exit 0 — self-heals against its own clobber ✔
- **Idempotence**: second consecutive run identical `PASS` ✔
- `npx eslint scripts/dev/check-native.mjs` clean; `npm run typecheck` clean ✔
- Full `npx vitest run`: **217/217 files, 2898/2898 tests** — same green count as CI on the base commit (d5ab75f8) ✔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native database compatibility checks across Electron and Node.js environments.
  * Added validation to ensure database functionality remains available for tests after Electron checks.
  * Preserved existing database binaries after compatibility verification to prevent development and test disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->