### PR TITLE
fix(deps): patch 5 Python security advisories (Dependabot triage)

### DIFF
--- a/docs/development/DEPENDABOT_TRIAGE_2026-07-15.md
+++ b/docs/development/DEPENDABOT_TRIAGE_2026-07-15.md
@@ -1,0 +1,101 @@
+# Dependabot Vulnerability Triage — 2026-07-15
+
+Triage of the 15 open Dependabot alerts on `sgeraldes/hidock-next` (7 high, 5 moderate,
+3 low). Source: <https://github.com/sgeraldes/hidock-next/security/dependabot>.
+
+Fixes land on `beta/meeting-intelligence` first per repo routing.
+
+## Summary
+
+| Outcome | Count | Alerts |
+| --- | --- | --- |
+| **Fixed** (this change) | 5 | #91, #73, #200, #114, #247 |
+| **Already patched on beta** (no action) | 6 | tar #25, #26, #29, #31, #63, #71 top-level |
+| **Blocked upstream / tracked** | 4 | torch #363, #364, #365; tar #323 residual |
+
+Net: the 5 Python alerts are resolved by upgrading `uv.lock`. The tar top-level exposure was
+already fixed on beta (`tar@7.5.17`). The remaining tar residue and all torch alerts are
+blocked by upstream constraints and are tracked below with remediation paths.
+
+## Alert-by-alert
+
+### Fixed — `uv.lock` (Python)
+
+All five constraints in `pyproject.toml` already permitted the patched versions, so these are
+pure lockfile bumps (`uv lock --upgrade-package …`), no manifest change.
+
+| Alert | Sev | Package | Scope | Was | Now | Patched at |
+| --- | --- | --- | --- | --- | --- | --- |
+| #73  | HIGH   | black    | dev (direct: `black>=24.4`)       | 26.1.0 | 26.5.1 | 26.3.1 | CVE-2026-32274 (arbitrary file write via cache filename) |
+| #91  | MEDIUM | requests | runtime (direct: `requests>=2.32.0`) | 2.32.5 | 2.34.2 | 2.33.0 | CVE-2026-25645 (insecure temp-file reuse in `extract_zipped_paths`) |
+| #200 | MEDIUM | pytest   | dev (direct: `pytest>=8.2`)       | 9.0.2  | 9.1.1  | 9.0.3  | CVE-2025-71176 (vulnerable tmpdir handling) |
+| #247 | MEDIUM | idna     | runtime (transitive via requests) | 3.11   | 3.18   | 3.15   | CVE-2026-45409 (`idna.encode()` bypass of CVE-2024-3651 fix) |
+| #114 | LOW    | Pygments | dev (transitive)                  | 2.19.2 | 2.20.0 | 2.20.0 | CVE-2026-4539 (ReDoS in GUID regex) |
+
+### Already patched on beta — `tar` top-level (dev)
+
+`apps/electron/package-lock.json` already resolves the top-level `tar` to **7.5.17** on both
+`beta` and `main`, which is above every patched threshold in these advisories. These alerts
+are stale against the current lockfile and should auto-close once Dependabot re-scans:
+
+- #25 CVE-2026-23745 (patched 7.5.3), #26 CVE-2026-23950 (7.5.4), #29 CVE-2026-24842 (7.5.7),
+  #31 CVE-2026-26960 (7.5.8), #63 CVE-2026-29786 (7.5.10), #71 CVE-2026-31802 (7.5.11).
+
+### Blocked / tracked — `tar@6.2.1` residue (#323, dev)
+
+**ACTION ITEM (deferred):** `apps/electron/package-lock.json` still contains three `tar@6.2.1`
+copies nested under native-build tooling:
+
+- `@electron/rebuild@3.7.2` → `tar ^6.0.5`
+- `@electron/node-gyp@10.2.0-electron.1` → `tar ^6.2.1`
+- `cacache@16.1.3` → `tar ^6.1.11`
+
+The open-ended advisory ranges (`tar <= 7.5.15`, patched **7.5.16**) technically include the
+6.x line, so Dependabot flags 6.2.1. **There is no patched `tar` 6.x release** — the 6.x line
+tops out at 6.2.1 and the fix exists only in 7.5.16+.
+
+Why not force it now:
+
+- **Dev/build-only, trusted inputs.** These run at `npm install` / `electron-builder
+  install-app-deps` / `electron-rebuild` time and only extract archives fetched from the npm
+  and Electron registries — not attacker-controlled tar files. The path-traversal CVEs require
+  processing a malicious archive.
+- **The only fixes perturb the protected native-rebuild toolchain.** A blanket npm `override`
+  forcing `tar@^7.5.16`, or a major bump of `@electron/rebuild` 3→4 (v4 drops the direct tar
+  dep), both run the `better-sqlite3` native rebuild on a new tar/toolchain. That is precisely
+  the dual-ABI path guarded by `better-sqlite3-binding.smoke.test.ts`, and it is not a "safe
+  upgrade" for a dev-only, trusted-input dependency.
+
+**Remediation path:** in a dedicated PR, migrate `@electron/rebuild` 3.7.2 → 4.x (which drops
+the direct `tar` dependency and modernizes the node-gyp/cacache chain), then re-run
+`electron-builder install-app-deps` + the `better-sqlite3` dual-ABI smoke test across the
+Node-20/Node-22 ABI matrix before merging. Isolated from this security bump because it carries
+native-build regression risk.
+
+### Blocked upstream — `torch` (#363, #364, #365, `scripts/experiments/diarization/`)
+
+**ACTION ITEM (deferred):** `scripts/experiments/diarization/requirements.txt` pins
+`torch==2.8.0` / `torchaudio==2.8.0` / `torchvision==0.23.0` (+cu126) for a hardware-gated
+diarization spike (RTX 4090 / CUDA, gated HF models). It is a research spike — not installed by
+`setup.py`, not in any shipped app's dependency closure, and not exercised in CI.
+
+| Alert | Sev | CVE | Patched at | Status |
+| --- | --- | --- | --- | --- |
+| #363 | MEDIUM | CVE-2025-2999 (memory corruption in `unpack_sequence`) | 2.9.1 | blocked |
+| #365 | LOW | CVE-2025-3001 (memory corruption in `torch.lstm_cell`) | 2.10.0 | blocked |
+| #364 | LOW | CVE-2025-3000 (memory corruption in `torch.jit.script`) | **none** | unfixable |
+
+Why not bump:
+
+- **`whisperx` hard-pins the 2.8 line.** `whisperx==3.8.6` (and the current pre-release
+  `3.8.7rc1`) require `torch~=2.8.0`, `torchaudio~=2.8.0`, `torchvision~=0.23.0`. `~=2.8.0`
+  means `>=2.8.0, <2.9.0`, so torch cannot move to 2.9.1 or 2.10.0 without dropping/replacing
+  whisperx. No published whisperx release supports torch ≥ 2.9.
+- **#364 has no patched version** in any torch line, so torch stays flagged regardless of a bump.
+- The spike's install procedure is order-sensitive and GPU/CUDA/gated-HF-specific; it cannot be
+  validated in this environment.
+
+**Remediation path:** revisit when an upstream `whisperx` release supports torch ≥ 2.10, then
+bump the trio to `torch==2.10.0 / torchaudio==2.10.0 / torchvision==0.25.0` and re-validate the
+spike end-to-end on GPU hardware. Until then the exposure is contained to a non-shipped,
+manually-run experiment.

--- a/docs/development/DEPENDABOT_TRIAGE_2026-07-15.md
+++ b/docs/development/DEPENDABOT_TRIAGE_2026-07-15.md
@@ -24,8 +24,8 @@ blocked by upstream constraints and are tracked below with remediation paths.
 All five constraints in `pyproject.toml` already permitted the patched versions, so these are
 pure lockfile bumps (`uv lock --upgrade-package …`), no manifest change.
 
-| Alert | Sev | Package | Scope | Was | Now | Patched at |
-| --- | --- | --- | --- | --- | --- | --- |
+| Alert | Sev | Package | Scope | Was | Now | Patched at | CVE |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | #73  | HIGH   | black    | dev (direct: `black>=24.4`)       | 26.1.0 | 26.5.1 | 26.3.1 | CVE-2026-32274 (arbitrary file write via cache filename) |
 | #91  | MEDIUM | requests | runtime (direct: `requests>=2.32.0`) | 2.32.5 | 2.34.2 | 2.33.0 | CVE-2026-25645 (insecure temp-file reuse in `extract_zipped_paths`) |
 | #200 | MEDIUM | pytest   | dev (direct: `pytest>=8.2`)       | 9.0.2  | 9.1.1  | 9.0.3  | CVE-2025-71176 (vulnerable tmpdir handling) |

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "black"
-version = "26.1.0"
+version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -14,24 +14,24 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785, upload-time = "2026-01-18T04:50:11.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/13/710298938a61f0f54cdb4d1c0baeb672c01ff0358712eddaf29f76d32a0b/black-26.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6eeca41e70b5f5c84f2f913af857cf2ce17410847e1d54642e658e078da6544f", size = 1878189, upload-time = "2026-01-18T04:59:30.682Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a6/5179beaa57e5dbd2ec9f1c64016214057b4265647c62125aa6aeffb05392/black-26.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dd39eef053e58e60204f2cdf059e2442e2eb08f15989eefe259870f89614c8b6", size = 1700178, upload-time = "2026-01-18T04:59:32.387Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/04/c96f79d7b93e8f09d9298b333ca0d31cd9b2ee6c46c274fd0f531de9dc61/black-26.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9459ad0d6cd483eacad4c6566b0f8e42af5e8b583cee917d90ffaa3778420a0a", size = 1777029, upload-time = "2026-01-18T04:59:33.767Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f9/71c161c4c7aa18bdda3776b66ac2dc07aed62053c7c0ff8bbda8c2624fe2/black-26.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a19915ec61f3a8746e8b10adbac4a577c6ba9851fa4a9e9fbfbcf319887a5791", size = 1406466, upload-time = "2026-01-18T04:59:35.177Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/8b/a7b0f974e473b159d0ac1b6bcefffeb6bec465898a516ee5cc989503cbc7/black-26.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:643d27fb5facc167c0b1b59d0315f2674a6e950341aed0fc05cf307d22bf4954", size = 1216393, upload-time = "2026-01-18T04:59:37.18Z" },
-    { url = "https://files.pythonhosted.org/packages/79/04/fa2f4784f7237279332aa735cdfd5ae2e7730db0072fb2041dadda9ae551/black-26.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ba1d768fbfb6930fc93b0ecc32a43d8861ded16f47a40f14afa9bb04ab93d304", size = 1877781, upload-time = "2026-01-18T04:59:39.054Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ad/5a131b01acc0e5336740a039628c0ab69d60cf09a2c87a4ec49f5826acda/black-26.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b807c240b64609cb0e80d2200a35b23c7df82259f80bef1b2c96eb422b4aac9", size = 1699670, upload-time = "2026-01-18T04:59:41.005Z" },
-    { url = "https://files.pythonhosted.org/packages/da/7c/b05f22964316a52ab6b4265bcd52c0ad2c30d7ca6bd3d0637e438fc32d6e/black-26.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1de0f7d01cc894066a1153b738145b194414cc6eeaad8ef4397ac9abacf40f6b", size = 1775212, upload-time = "2026-01-18T04:59:42.545Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/a3/e8d1526bea0446e040193185353920a9506eab60a7d8beb062029129c7d2/black-26.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:91a68ae46bf07868963671e4d05611b179c2313301bd756a89ad4e3b3db2325b", size = 1409953, upload-time = "2026-01-18T04:59:44.357Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5a/d62ebf4d8f5e3a1daa54adaab94c107b57be1b1a2f115a0249b41931e188/black-26.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:be5e2fe860b9bd9edbf676d5b60a9282994c03fbbd40fe8f5e75d194f96064ca", size = 1217707, upload-time = "2026-01-18T04:59:45.719Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/83/be35a175aacfce4b05584ac415fd317dd6c24e93a0af2dcedce0f686f5d8/black-26.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9dc8c71656a79ca49b8d3e2ce8103210c9481c57798b48deeb3a8bb02db5f115", size = 1871864, upload-time = "2026-01-18T04:59:47.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/f5/d33696c099450b1274d925a42b7a030cd3ea1f56d72e5ca8bbed5f52759c/black-26.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b22b3810451abe359a964cc88121d57f7bce482b53a066de0f1584988ca36e79", size = 1701009, upload-time = "2026-01-18T04:59:49.443Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/87/670dd888c537acb53a863bc15abbd85b22b429237d9de1b77c0ed6b79c42/black-26.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53c62883b3f999f14e5d30b5a79bd437236658ad45b2f853906c7cbe79de00af", size = 1767806, upload-time = "2026-01-18T04:59:50.769Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9c/cd3deb79bfec5bcf30f9d2100ffeec63eecce826eb63e3961708b9431ff1/black-26.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:f016baaadc423dc960cdddf9acae679e71ee02c4c341f78f3179d7e4819c095f", size = 1433217, upload-time = "2026-01-18T04:59:52.218Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/29/f3be41a1cf502a283506f40f5d27203249d181f7a1a2abce1c6ce188035a/black-26.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:66912475200b67ef5a0ab665011964bf924745103f51977a78b4fb92a9fc1bf0", size = 1245773, upload-time = "2026-01-18T04:59:54.457Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", size = 204010, upload-time = "2026-01-18T04:50:09.978Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -187,11 +187,11 @@ provides-extras = ["desktop", "audio", "integration", "dev"]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -351,16 +351,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -369,9 +369,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -435,9 +435,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Triage of all **15 open Dependabot alerts** (7 high, 5 moderate, 3 low) and application of
the safe subset. Targets `beta/meeting-intelligence` per repo routing.

Full write-up: `docs/development/DEPENDABOT_TRIAGE_2026-07-15.md`.

## Fixed here — 5 Python alerts (`uv.lock` only)

Every constraint in `pyproject.toml` already permitted the patched version, so this is a
pure lockfile bump — no manifest changes.

| Alert | Sev | Package | Scope | Was → Now | CVE |
| --- | --- | --- | --- | --- | --- |
| #73  | HIGH   | black    | dev (direct)      | 26.1.0 → 26.5.1 | CVE-2026-32274 |
| #91  | MEDIUM | requests | runtime (direct)  | 2.32.5 → 2.34.2 | CVE-2026-25645 |
| #200 | MEDIUM | pytest   | dev (direct)      | 9.0.2 → 9.1.1   | CVE-2025-71176 |
| #247 | MEDIUM | idna     | runtime (transitive) | 3.11 → 3.18  | CVE-2026-45409 |
| #114 | LOW    | Pygments | dev (transitive)  | 2.19.2 → 2.20.0 | CVE-2026-4539 |

## Not changed here — with reasons (tracked)

- **tar #25/#26/#29/#31/#63/#71 (HIGH/MED, dev):** the top-level `tar` in
  `apps/electron/package-lock.json` is **already `7.5.17`** on `beta` and `main` — above every
  patched threshold. These should auto-close on the next Dependabot re-scan.
- **tar #323 (MED, dev):** three `tar@6.2.1` copies remain nested under native-build tooling
  (`@electron/rebuild` 3.7.2 → `@electron/node-gyp`, `cacache`). **No patched `tar` 6.x exists**
  (6.x tops out at 6.2.1; fix is only in 7.5.16+). The only fixes — a blanket `tar@^7` override
  or an `@electron/rebuild` 3→4 major bump — both run the **better-sqlite3 native rebuild** on a
  new tar/toolchain, i.e. the dual-ABI path guarded by `better-sqlite3-binding.smoke.test.ts`.
  Not a "safe upgrade" for a dev-only, trusted-input (npm/Electron registry) dependency.
  → **Action item:** migrate to `@electron/rebuild` 4.x in a dedicated PR and revalidate the
  better-sqlite3 ABI smoke test.
- **torch #363/#364/#365 (MED/LOW, non-shipped spike):**
  `scripts/experiments/diarization/requirements.txt` pins `torch==2.8.0`. `whisperx==3.8.6`
  (and `3.8.7rc1`) hard-pin `torch~=2.8.0`, so torch cannot move to the patched 2.9.1/2.10.0
  line without replacing whisperx. #364 (CVE-2025-3000) has **no patched version** in any torch
  release. The file is a hardware-gated research spike — not installed by `setup.py`, not in any
  shipped app, not in CI. → **Action item:** bump when an upstream whisperx supports torch ≥ 2.10
  and re-validate the CUDA spike on GPU.

## Verification

- `uv lock` re-resolved all 28 packages cleanly with the 5 patched versions.
- **Electron:** `npx vitest run` → 3514/3515 pass. The single failure
  (`context-graph/layout.test.ts` date-axis tick test) is a **load-induced flake** — a heavy
  dynamic `await import()` exceeding the default 5000 ms timeout under full-suite parallelism;
  it passes 23/23 in isolation (import 38 ms). Pre-existing on `beta`, unrelated to this
  Python-only change; being fixed separately with a `testTimeout` bump.
- **Web:** `npm test` → 36/36 pass.

This diff touches only `uv.lock` + docs, so it cannot affect the electron/web test suites; both
runs are baseline confirmations that the env is green.
