### PR TITLE
chore(electron): clear all 93 eslint warnings

### DIFF
--- a/apps/electron/electron/main/ipc/__tests__/actionables-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/actionables-handlers.test.ts
@@ -17,12 +17,12 @@ vi.mock('../../services/database', () => ({
 }))
 
 describe('Actionables IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/ipc/__tests__/artifact-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/artifact-handlers.test.ts
@@ -16,12 +16,12 @@ vi.mock('../../services/artifact-service', () => ({
 }))
 
 describe('Artifact IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as never
     })

--- a/apps/electron/electron/main/ipc/__tests__/briefing-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/briefing-handlers.test.ts
@@ -31,12 +31,12 @@ function routeQueryAll(routes: Array<{ match: RegExp; rows: unknown[] }>) {
 }
 
 describe('Briefing IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/ipc/__tests__/calendar-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/calendar-handlers.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../services/database', () => ({
 }))
 
 describe('Calendar IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   // Default config returned by getConfig
   const defaultConfig = {
@@ -45,7 +45,7 @@ describe('Calendar IPC Handlers', () => {
     const { getConfig } = await import('../../services/config')
     vi.mocked(getConfig).mockReturnValue(defaultConfig as any)
 
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })
@@ -332,7 +332,7 @@ describe('Calendar IPC Handlers', () => {
       // Re-register to trigger initialization with new config
       handlers = {}
       vi.mocked(ipcMain.handle).mockClear()
-      vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+      vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
         handlers[channel] = handler
         return undefined as any
       })

--- a/apps/electron/electron/main/ipc/__tests__/git-commits-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/git-commits-handlers.test.ts
@@ -24,12 +24,12 @@ const sampleCommit: TodayCommit = {
 }
 
 describe('Git Commits IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(() => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/ipc/__tests__/knowledge-getByIds.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/knowledge-getByIds.test.ts
@@ -19,13 +19,13 @@ vi.mock('../../services/database', () => ({
 }))
 
 describe('knowledge:getByIds handler (B-CHAT-004)', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(() => {
     vi.clearAllMocks()
     handlers = {}
-    // @ts-ignore
-    ipcMain.handle.mockImplementation((channel: string, handler: Function) => {
+    // @ts-expect-error mock method not present on typed import
+    ipcMain.handle.mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
     })
     registerKnowledgeHandlers()
@@ -68,7 +68,7 @@ describe('knowledge:getByIds handler (B-CHAT-004)', () => {
         status: 'enriched'
       }
     ]
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     queryAll.mockReturnValue(mockRows)
 
     const result = await handlers['knowledge:getByIds']({}, ['kc-1', 'kc-2'])
@@ -93,7 +93,7 @@ describe('knowledge:getByIds handler (B-CHAT-004)', () => {
   })
 
   it('should build correct number of placeholders for IDs', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     queryAll.mockReturnValue([])
 
     await handlers['knowledge:getByIds']({}, ['a', 'b', 'c'])
@@ -105,7 +105,7 @@ describe('knowledge:getByIds handler (B-CHAT-004)', () => {
   })
 
   it('should handle single ID', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     queryAll.mockReturnValue([{
       id: 'single',
       title: 'Single Item',
@@ -123,7 +123,7 @@ describe('knowledge:getByIds handler (B-CHAT-004)', () => {
   })
 
   it('should return empty array on database error', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     queryAll.mockImplementation(() => { throw new Error('DB Error') })
 
     const result = await handlers['knowledge:getByIds']({}, ['kc-1'])
@@ -131,7 +131,7 @@ describe('knowledge:getByIds handler (B-CHAT-004)', () => {
   })
 
   it('should not use SELECT * in the query', async () => {
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     queryAll.mockReturnValue([])
 
     await handlers['knowledge:getByIds']({}, ['kc-1'])

--- a/apps/electron/electron/main/ipc/__tests__/knowledge-graph-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/knowledge-graph-handlers.test.ts
@@ -51,12 +51,12 @@ import { getContactByName } from '../../services/database'
 import { registerKnowledgeGraphHandlers } from '../knowledge-graph-handlers'
 
 describe('knowledge-graph IPC handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(() => {
     vi.clearAllMocks()
     handlers = {}
-    ;(ipcMain.handle as any).mockImplementation((channel: string, handler: Function) => {
+    ;(ipcMain.handle as any).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
     })
     registerKnowledgeGraphHandlers()

--- a/apps/electron/electron/main/ipc/__tests__/knowledge-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/knowledge-handlers.test.ts
@@ -19,12 +19,12 @@ vi.mock('../../services/database', () => ({
 }))
 
 describe('Knowledge IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(() => {
     vi.clearAllMocks()
     handlers = {}
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     ipcMain.handle.mockImplementation((channel, handler) => {
       handlers[channel] = handler
     })
@@ -48,7 +48,7 @@ describe('Knowledge IPC Handlers', () => {
           source_recording_id: 'rec-1'
         }
       ]
-      // @ts-ignore
+      // @ts-expect-error mock method not present on typed import
       queryAll.mockReturnValue(mockRows)
 
       const result = await handlers['knowledge:getAll']({}, { limit: 10, offset: 0 })
@@ -72,7 +72,7 @@ describe('Knowledge IPC Handlers', () => {
     })
 
     it('should return empty array on database error', async () => {
-      // @ts-ignore
+      // @ts-expect-error mock method not present on typed import
       queryAll.mockImplementation(() => { throw new Error('DB Error') })
       const result = await handlers['knowledge:getAll']({})
       expect(result).toEqual([])
@@ -82,7 +82,7 @@ describe('Knowledge IPC Handlers', () => {
   describe('knowledge:getById', () => {
     it('should return mapped capture if found', async () => {
       const mockRow = { id: '1', title: 'Single' }
-      // @ts-ignore
+      // @ts-expect-error mock method not present on typed import
       queryOne.mockReturnValue(mockRow)
 
       const result = await handlers['knowledge:getById']({}, '1')
@@ -92,7 +92,7 @@ describe('Knowledge IPC Handlers', () => {
     })
 
     it('should return null if not found', async () => {
-      // @ts-ignore
+      // @ts-expect-error mock method not present on typed import
       queryOne.mockReturnValue(null)
       const result = await handlers['knowledge:getById']({}, '99')
       expect(result).toBeNull()
@@ -111,7 +111,7 @@ describe('Knowledge IPC Handlers', () => {
     })
 
     it('should return error on failure', async () => {
-      // @ts-ignore
+      // @ts-expect-error mock method not present on typed import
       run.mockImplementation(() => { throw new Error('Update failed') })
       const result = await handlers['knowledge:update']({}, '1', { title: 'X' })
       expect(result.success).toBe(false)

--- a/apps/electron/electron/main/ipc/__tests__/outputs-handlers-b001.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/outputs-handlers-b001.test.ts
@@ -85,12 +85,12 @@ vi.mock('crypto', async () => {
 })
 
 describe('Outputs IPC Handlers - B-ACT-001 & B-ACT-004', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/ipc/__tests__/outputs-launch-claude.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/outputs-launch-claude.test.ts
@@ -66,12 +66,12 @@ vi.mock('crypto', async () => {
 })
 
 describe('outputs:launchClaudeCode', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/ipc/__tests__/recording-handlers.test.ts
+++ b/apps/electron/electron/main/ipc/__tests__/recording-handlers.test.ts
@@ -136,12 +136,12 @@ vi.mock('../../services/config', () => ({
 }))
 
 describe('Recording IPC Handlers', () => {
-  let handlers: Record<string, Function> = {}
+  let handlers: Record<string, (...args: any[]) => any> = {}
 
   beforeEach(async () => {
     vi.clearAllMocks()
     handlers = {}
-    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: (...args: any[]) => any) => {
       handlers[channel] = handler
       return undefined as any
     })

--- a/apps/electron/electron/main/services/database.ts
+++ b/apps/electron/electron/main/services/database.ts
@@ -781,7 +781,7 @@ const MIGRATIONS: Record<number, () => void> = {
     for (const sql of columnsToAdd) {
       try {
         database.run(sql)
-      } catch (e) {
+      } catch {
         // Column likely already exists, ignore
         console.log(`Column may already exist: ${sql}`)
       }
@@ -865,7 +865,7 @@ const MIGRATIONS: Record<number, () => void> = {
           }
           console.log('[Migration v7] Updated device_files_cache durations')
         }
-      } catch (e) {
+      } catch {
         // device_files_cache may not exist
         console.log('[Migration v7] device_files_cache not found or empty')
       }
@@ -943,7 +943,7 @@ const MIGRATIONS: Record<number, () => void> = {
           }
           console.log('[Migration v8] Fixed device_files_cache durations')
         }
-      } catch (e) {
+      } catch {
         console.log('[Migration v8] device_files_cache not found or empty')
       }
     } catch (e) {
@@ -1022,7 +1022,7 @@ const MIGRATIONS: Record<number, () => void> = {
           }
           console.log('[Migration v9] Fixed device_files_cache durations')
         }
-      } catch (e) {
+      } catch {
         console.log('[Migration v9] device_files_cache not found or empty')
       }
     } catch (e) {
@@ -1044,7 +1044,7 @@ const MIGRATIONS: Record<number, () => void> = {
         CHECK(storage_tier IN (NULL, 'hot', 'warm', 'cold', 'archive'))
       `)
       console.log('[Migration v10] Added storage_tier column to recordings')
-    } catch (e) {
+    } catch {
       // Column likely already exists
       console.log('[Migration v10] storage_tier column may already exist')
     }
@@ -1053,7 +1053,7 @@ const MIGRATIONS: Record<number, () => void> = {
     try {
       database.run('CREATE INDEX IF NOT EXISTS idx_recordings_storage_tier ON recordings(storage_tier)')
       console.log('[Migration v10] Created storage_tier index')
-    } catch (e) {
+    } catch {
       console.log('[Migration v10] storage_tier index may already exist')
     }
 
@@ -1079,7 +1079,7 @@ const MIGRATIONS: Record<number, () => void> = {
           "ALTER TABLE recordings ADD COLUMN migrated_at TEXT"
         ]
         for (const sql of columnsToAdd) {
-          try { database.run(sql) } catch (e) { /* ignore duplicate */ }
+          try { database.run(sql) } catch { /* ignore duplicate */ }
         }
       }
 
@@ -1094,7 +1094,7 @@ const MIGRATIONS: Record<number, () => void> = {
           const schemaSQL = readFileSync(schemaPath, 'utf-8')
           const statements = schemaSQL.split('\n').filter(line => !line.trim().startsWith('--')).join('\n').split(';').map(s => s.trim()).filter(s => s.length > 0)
           for (const sql of statements) {
-            try { database.run(sql) } catch (e) { /* ignore existing */ }
+            try { database.run(sql) } catch { /* ignore existing */ }
           }
         }
       } else {
@@ -1155,7 +1155,7 @@ const MIGRATIONS: Record<number, () => void> = {
     try {
       database.run('ALTER TABLE chat_messages ADD COLUMN conversation_id TEXT REFERENCES conversations(id) ON DELETE CASCADE')
       console.log('[Migration v12] Added conversation_id column to chat_messages')
-    } catch (e) {
+    } catch {
       console.log('[Migration v12] conversation_id column may already exist')
     }
 
@@ -1177,7 +1177,7 @@ const MIGRATIONS: Record<number, () => void> = {
     for (const sql of columnsToAdd) {
       try {
         database.run(sql)
-      } catch (e) {
+      } catch {
         console.log(`Column may already exist: ${sql}`)
       }
     }
@@ -1191,7 +1191,7 @@ const MIGRATIONS: Record<number, () => void> = {
     try {
       database.run("ALTER TABLE projects ADD COLUMN status TEXT CHECK(status IN ('active', 'archived')) DEFAULT 'active'")
       console.log('[Migration v14] Added status column to projects')
-    } catch (e) {
+    } catch {
       console.log('[Migration v14] status column may already exist')
     }
     console.log('Migration v14 complete: Projects table enhanced')
@@ -1214,7 +1214,7 @@ const MIGRATIONS: Record<number, () => void> = {
     for (const sql of columnsToAdd) {
       try {
         database.run(sql)
-      } catch (e) {
+      } catch {
         // Column likely already exists, ignore
         console.log(`Column may already exist: ${sql}`)
       }
@@ -2155,7 +2155,7 @@ function repairPhase(): void {
     for (const col of meetingRepairs) {
       if (!meetingCols.includes(col.name)) {
         console.log(`[Database] Repairing meetings: adding ${col.name}`)
-        try { database.run(`ALTER TABLE meetings ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+        try { database.run(`ALTER TABLE meetings ADD COLUMN ${col.name} ${col.def}`) } catch {}
       }
     }
   }
@@ -2175,7 +2175,7 @@ function repairPhase(): void {
     for (const col of recordingRepairs) {
       if (!recCols.includes(col.name)) {
         console.log(`[Database] Repairing recordings: adding ${col.name}`)
-        try { database.run(`ALTER TABLE recordings ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+        try { database.run(`ALTER TABLE recordings ADD COLUMN ${col.name} ${col.def}`) } catch {}
       }
     }
   } else {
@@ -2202,7 +2202,7 @@ function repairPhase(): void {
     for (const col of knowledgeRepairs) {
       if (!capCols.includes(col.name)) {
         console.log(`[Database] Repairing knowledge_captures: adding ${col.name}`)
-        try { database.run(`ALTER TABLE knowledge_captures ADD COLUMN ${col.def}`) } catch (e) {}
+        try { database.run(`ALTER TABLE knowledge_captures ADD COLUMN ${col.def}`) } catch {}
       }
     }
   } else {
@@ -2221,7 +2221,7 @@ function repairPhase(): void {
     for (const col of queueRepairs) {
       if (!queueCols.includes(col.name)) {
         console.log(`[Database] Repairing transcription_queue: adding ${col.name}`)
-        try { database.run(`ALTER TABLE transcription_queue ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+        try { database.run(`ALTER TABLE transcription_queue ADD COLUMN ${col.name} ${col.def}`) } catch {}
       }
     }
   }
@@ -2246,7 +2246,7 @@ function repairPhase(): void {
         FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
       )
     `)
-  } catch (e) { /* table already exists */ }
+  } catch { /* table already exists */ }
 
   // Repair transcript_speakers (v25): a new table has no columns to ALTER, but
   // force-create it here so an older on-disk DB that skipped the migration still
@@ -2264,7 +2264,7 @@ function repairPhase(): void {
         FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
       )
     `)
-  } catch (e) { /* table already exists */ }
+  } catch { /* table already exists */ }
 
   // Repair mention_resolutions (v35): force-create so an older on-disk DB that
   // skipped the migration still gets it before any resolveMention write. Idempotent.
@@ -2330,7 +2330,7 @@ function repairPhase(): void {
         FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
       )
     `)
-  } catch (e) { /* table already exists */ }
+  } catch { /* table already exists */ }
 
   // Repair alias memory + suggestion tables (v27): force-create so an older
   // on-disk DB that skipped the migration still gets them. Idempotent.
@@ -2373,7 +2373,7 @@ function repairPhase(): void {
     database.run('CREATE INDEX IF NOT EXISTS idx_contact_aliases_contact ON contact_aliases(contact_id)')
     database.run('CREATE INDEX IF NOT EXISTS idx_project_aliases_project ON project_aliases(project_id)')
     database.run('CREATE INDEX IF NOT EXISTS idx_identity_suggestions_status ON identity_suggestions(status)')
-  } catch (e) { /* tables already exist */ }
+  } catch { /* tables already exist */ }
 
   // Repair artifacts table (v28): force-create so an older on-disk DB that
   // skipped the migration still gets it before any importArtifact write. Idempotent.
@@ -2398,13 +2398,13 @@ function repairPhase(): void {
     database.run('CREATE INDEX IF NOT EXISTS idx_artifacts_capture ON artifacts(knowledge_capture_id)')
     database.run('CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind)')
     database.run('CREATE INDEX IF NOT EXISTS idx_artifacts_content_hash ON artifacts(content_hash)')
-  } catch (e) { /* table already exists */ }
+  } catch { /* table already exists */ }
 
   // Repair action_items (v26): force-add assignee_contact_id if missing.
   const actionItemCols = getTableColumns(database, 'action_items')
   if (actionItemCols.length > 0 && !actionItemCols.includes('assignee_contact_id')) {
     console.log('[Database] Repairing action_items: adding assignee_contact_id')
-    try { database.run('ALTER TABLE action_items ADD COLUMN assignee_contact_id TEXT') } catch (e) {}
+    try { database.run('ALTER TABLE action_items ADD COLUMN assignee_contact_id TEXT') } catch {}
   }
 
   // Repair transcripts (v39): force-add the meeting-timeline JSON columns so an
@@ -2415,7 +2415,7 @@ function repairPhase(): void {
     for (const col of ['sentiment_segments', 'event_markers']) {
       if (!transcriptCols.includes(col)) {
         console.log(`[Database] Repairing transcripts: adding ${col}`)
-        try { database.run(`ALTER TABLE transcripts ADD COLUMN ${col} TEXT`) } catch (e) {}
+        try { database.run(`ALTER TABLE transcripts ADD COLUMN ${col} TEXT`) } catch {}
       }
     }
   }
@@ -2426,7 +2426,7 @@ function repairPhase(): void {
     for (const col of ['folder_path', 'url']) {
       if (!projectCols.includes(col)) {
         console.log(`[Database] Repairing projects: adding ${col}`)
-        try { database.run(`ALTER TABLE projects ADD COLUMN ${col} TEXT`) } catch (e) {}
+        try { database.run(`ALTER TABLE projects ADD COLUMN ${col} TEXT`) } catch {}
       }
     }
   }
@@ -2447,7 +2447,7 @@ function repairPhase(): void {
       )
     `)
     database.run('CREATE INDEX IF NOT EXISTS idx_project_notes_project_kind ON project_notes(project_id, kind)')
-  } catch (e) { /* table already exists */ }
+  } catch { /* table already exists */ }
 
   // Repair chat_messages (AI-15: columns referenced by assistant mapper)
   const chatMsgInfo = database.exec("PRAGMA table_info(chat_messages)")
@@ -2462,7 +2462,7 @@ function repairPhase(): void {
     for (const col of chatRepairs) {
       if (!chatCols.includes(col.name)) {
         console.log(`[Database] Repairing chat_messages: adding ${col.name}`)
-        try { database.run(`ALTER TABLE chat_messages ADD COLUMN ${col.name} ${col.def}`) } catch (e) {}
+        try { database.run(`ALTER TABLE chat_messages ADD COLUMN ${col.name} ${col.def}`) } catch {}
       }
     }
   }
@@ -2887,7 +2887,7 @@ function extractContactsFromMeetingDataInternal(meeting: Omit<Meeting, 'created_
           emailsToLookup.push(attendee.email)
         }
       }
-    } catch (e) {
+    } catch {
       // Invalid JSON, skip attendees
     }
   }

--- a/apps/electron/src/components/HealthCheck.tsx
+++ b/apps/electron/src/components/HealthCheck.tsx
@@ -358,7 +358,7 @@ export function HealthCheck() {
               <div>
                 <div className="text-sm font-medium mb-2 text-red-600 dark:text-red-400">Purge Orphaned Records</div>
                 <p className="text-xs text-muted-foreground mb-3">
-                  Delete ALL database records where the audio file doesn't exist on disk.
+                  Delete ALL database records where the audio file doesn&apos;t exist on disk.
                   Use this if Health Check finds no issues but the Library still shows deleted files.
                 </p>
                 <Button

--- a/apps/electron/src/components/actionables/ActionableDetail.tsx
+++ b/apps/electron/src/components/actionables/ActionableDetail.tsx
@@ -110,7 +110,7 @@ export function ActionableDetail({ actionable, resolveRecipient }: ActionableDet
       {actionable.description && (
         <DetailSection icon={FileText} label="What was detected">
           <p className="italic text-muted-foreground leading-relaxed whitespace-pre-wrap">
-            "{actionable.description}"
+            &quot;{actionable.description}&quot;
           </p>
         </DetailSection>
       )}

--- a/apps/electron/src/components/layout/Layout.tsx
+++ b/apps/electron/src/components/layout/Layout.tsx
@@ -204,6 +204,7 @@ export function Layout({ children }: LayoutProps) {
     loadConfig()
     loadMeetings()
     // loadRecordings() // Redundant: Pages load their own data via useUnifiedRecordings
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount to initialize app data
   }, [])
 
   // Toast notifications for device state changes (read from store)
@@ -241,6 +242,7 @@ export function Layout({ children }: LayoutProps) {
     }
 
     prevConnectedRef.current = isNowConnected
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- connectionStatus.step only read in the null-init guard; effect is intentionally keyed on device connection state
   }, [deviceState.connected, deviceState.model])
 
   // Toast notifications for connection errors (read from store)
@@ -270,6 +272,7 @@ export function Layout({ children }: LayoutProps) {
     if (config?.calendar.icsUrl && !lastCalendarSync) {
       syncCalendar()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initial sync only; keyed on icsUrl so it does not re-run when lastCalendarSync updates
   }, [config?.calendar.icsUrl])
 
   return (

--- a/apps/electron/src/features/library/components/BulkProgressModal.tsx
+++ b/apps/electron/src/features/library/components/BulkProgressModal.tsx
@@ -181,6 +181,7 @@ export function BulkProgressModal({
     if (progress.current > 0) {
       setAnnouncement(`${progress.current} of ${progress.total} items processed`)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- announce only on current/total changes, not on progress object identity
   }, [progress.current, progress.total])
 
   // Determine close behavior

--- a/apps/electron/src/features/library/components/SourceDetailDrawer.tsx
+++ b/apps/electron/src/features/library/components/SourceDetailDrawer.tsx
@@ -462,7 +462,7 @@ export function SourceDetailDrawer({
             ) : needsTranscription ? (
               <div className="text-center py-8 text-muted-foreground">
                 <Wand2 className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                <p className="text-sm">This capture hasn't been transcribed yet.</p>
+                <p className="text-sm">This capture hasn&apos;t been transcribed yet.</p>
                 <Button variant="outline" size="sm" onClick={onTranscribe} className="mt-4">
                   Start Transcription
                 </Button>

--- a/apps/electron/src/features/library/hooks/__tests__/useLibraryFilterManager.test.ts
+++ b/apps/electron/src/features/library/hooks/__tests__/useLibraryFilterManager.test.ts
@@ -61,7 +61,7 @@ describe('useLibraryFilterManager', () => {
     }
 
     // Mock useLibraryStore implementation
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     useLibraryStore.mockImplementation((selector) => {
       const fullState = { ...storeState, ...storeActions }
       return selector(fullState)

--- a/apps/electron/src/features/library/hooks/__tests__/useTransitionFilters.test.ts
+++ b/apps/electron/src/features/library/hooks/__tests__/useTransitionFilters.test.ts
@@ -35,7 +35,7 @@ describe('useTransitionFilters', () => {
       clearFilters: vi.fn()
     }
 
-    // @ts-ignore
+    // @ts-expect-error mock method not present on typed import
     useLibraryFilterManager.mockReturnValue(mockFilterManager)
   })
 

--- a/apps/electron/src/hooks/useBulkOperation.ts
+++ b/apps/electron/src/hooks/useBulkOperation.ts
@@ -195,6 +195,7 @@ export function useBulkOperation<T>(options: BulkOperationOptions<T>): BulkOpera
     if (options.items.length > 0) {
       start(options.items)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- auto-start with initial items on mount only
   }, []) // Only run on mount
 
   // Cleanup on unmount - abort any running operations

--- a/apps/electron/src/hooks/useDeviceSubscriptions.ts
+++ b/apps/electron/src/hooks/useDeviceSubscriptions.ts
@@ -249,7 +249,6 @@ export function useDeviceSubscriptions() {
       // When the component truly unmounts and remounts, React creates a NEW ref(false).
     }
   // SM-M02: Dependencies are stable (deviceService is singleton), refs handle action freshness
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceService])
 
   // ---- Live-recording signal (CMD 18 poll → jensen:recording-changed push) ----
@@ -387,6 +386,5 @@ export function useDeviceSubscriptions() {
       unsubDeviceDisconnect()
     }
   // SM-M02: Dependencies are stable (deviceService is singleton), refs handle action freshness
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceService])
 }

--- a/apps/electron/src/hooks/useDownloadOrchestrator.ts
+++ b/apps/electron/src/hooks/useDownloadOrchestrator.ts
@@ -618,6 +618,5 @@ export function useDownloadOrchestrator() {
     }
   // DL-11: Only depend on deviceService (stable singleton). processDownloadQueue
   // is accessed via ref so changes don't cause re-subscription.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deviceService])
 }

--- a/apps/electron/src/pages/Actionables.tsx
+++ b/apps/electron/src/pages/Actionables.tsx
@@ -675,7 +675,7 @@ export function Actionables() {
                             {actionable.title}
                           </h3>
                           {actionable.description && expandedId !== actionable.id && (
-                            <p className="text-sm text-muted-foreground mt-1 line-clamp-1 italic pr-4">"{actionable.description}"</p>
+                            <p className="text-sm text-muted-foreground mt-1 line-clamp-1 italic pr-4">&quot;{actionable.description}&quot;</p>
                           )}
                         </button>
                         <div className="flex items-center gap-3 mt-3">
@@ -896,7 +896,7 @@ export function Actionables() {
               </div>
               <p className="text-sm text-muted-foreground leading-relaxed">
                 HiDock automatically detects the intent to share information or follow up.
-                For example, after a meeting with a candidate, I'll suggest generating **Interview Feedback**.
+                For example, after a meeting with a candidate, I&apos;ll suggest generating **Interview Feedback**.
               </p>
             </CardContent>
           </Card>

--- a/apps/electron/src/pages/Chat.tsx
+++ b/apps/electron/src/pages/Chat.tsx
@@ -253,6 +253,7 @@ export function Chat() {
       }
     }
     initialize()
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialize chat once on mount
   }, [])
 
   // Load recording context
@@ -525,7 +526,7 @@ export function Chat() {
     try {
       const result = await window.electronAPI.rag.status()
       setStatus(result.success ? result.data : unavailable)
-    } catch (error) {
+    } catch {
       setStatus(unavailable)
     }
   }
@@ -1286,7 +1287,7 @@ export function Chat() {
                         </span>
                       </div>
                       <p className="text-xs line-clamp-3 text-muted-foreground italic">
-                        "{chunk.content}"
+                        &quot;{chunk.content}&quot;
                       </p>
                     </div>
                   ))}

--- a/apps/electron/src/pages/Device.tsx
+++ b/apps/electron/src/pages/Device.tsx
@@ -1483,7 +1483,7 @@ export function Device() {
                 <div className="space-y-2">
                   <h3 className="font-medium">1. Connect your device</h3>
                   <p className="text-sm text-muted-foreground">
-                    Plug in your HiDock via USB and click "Connect Device" to establish a connection
+                    Plug in your HiDock via USB and click &quot;Connect Device&quot; to establish a connection
                   </p>
                 </div>
                 <div className="space-y-2">

--- a/apps/electron/src/pages/Explore.tsx
+++ b/apps/electron/src/pages/Explore.tsx
@@ -494,7 +494,7 @@ export function Explore() {
                 {totalResults === 0 && !loading && (
                   <div className="text-center py-20 border-2 border-dashed rounded-3xl opacity-30">
                     <Search className="h-12 w-12 mx-auto mb-4" />
-                    <p className="text-sm">No results found for "{query}"</p>
+                    <p className="text-sm">No results found for &quot;{query}&quot;</p>
                   </div>
                 )}
                 {totalResults > 0 && !loading && activeTab !== 'all' && (() => {
@@ -506,8 +506,8 @@ export function Explore() {
                     return (
                       <div className="text-center py-12 border-2 border-dashed rounded-3xl opacity-30">
                         <Search className="h-10 w-10 mx-auto mb-3" />
-                        <p className="text-sm">No {activeTab} results for "{query}"</p>
-                        <p className="text-xs text-muted-foreground mt-1">Try the "all" tab to see results in other categories.</p>
+                        <p className="text-sm">No {activeTab} results for &quot;{query}&quot;</p>
+                        <p className="text-xs text-muted-foreground mt-1">Try the &quot;all&quot; tab to see results in other categories.</p>
                       </div>
                     )
                   }

--- a/apps/electron/src/pages/Projects.tsx
+++ b/apps/electron/src/pages/Projects.tsx
@@ -875,7 +875,7 @@ export function Projects() {
                             <div className="min-w-0 space-y-1">
                               <h3 className="text-sm font-bold">No items yet</h3>
                               <p className="text-sm text-muted-foreground">
-                                Add knowledge or link meetings to start building this project's hub.
+                                Add knowledge or link meetings to start building this project&apos;s hub.
                               </p>
                             </div>
                           </div>
@@ -1311,7 +1311,7 @@ export function Projects() {
                       <h3 className="font-bold text-sm uppercase tracking-wider">AI Project Insight</h3>
                     </div>
                     <p className="text-sm leading-relaxed text-muted-foreground italic">
-                      AI-generated insights for "{activeProject.name}" will appear here once knowledge items are linked to this project.
+                      AI-generated insights for &quot;{activeProject.name}&quot; will appear here once knowledge items are linked to this project.
                     </p>
                     <div className="mt-4 flex gap-2">
                       <Button


### PR DESCRIPTION
## Summary

`cd apps/electron && npm run lint` reported **93 warnings, 0 errors** on `beta/meeting-intelligence`. This makes the lint run **fully clean (0 problems)** without changing any runtime behavior or visible copy.

## What changed, by rule

| Rule | Count | Fix |
|------|-------|-----|
| `react/no-unescaped-entities` | 20 | Escape `"` → `&quot;` and `'` → `&apos;` in JSX **text nodes** only. Rendered output is byte-identical. Files: HealthCheck, ActionableDetail, SourceDetailDrawer, Actionables, Device, Explore, Projects, Chat. |
| `@typescript-eslint/no-unused-vars` | 28 | Convert 27 unused `catch (e)` in `database.ts` (+1 in Chat) to **optional catch bindings** (`catch {`), matching the `07a0f0bd` convention. Only the 27 flagged (unused) bindings were touched; the 42 `catch (e)` that use `e` are untouched. |
| `@typescript-eslint/no-unsafe-function-type` | 22 | Replace bare `Function` with `(...args: any[]) => any` in ipc-handler test mock registries. |
| `@typescript-eslint/ban-ts-comment` | 14 | Convert `@ts-ignore` → `@ts-expect-error <reason>` in tests (each suppresses a genuine mock-typing error, so `@ts-expect-error` is not itself unused). |
| `react-hooks/exhaustive-deps` | 6 | Annotate intentionally-scoped effects (mount-only init, ref-based prev-state tracking) with targeted `eslint-disable-next-line` + a reason. No dependency arrays were changed, so effect timing is unchanged. |
| unused `eslint-disable` directives | 3 | Remove 3 now-unnecessary `// eslint-disable-next-line react-hooks/exhaustive-deps` (deps arrays are already complete). |

## Verification

- `npm run lint` → **0 problems**
- `npm run typecheck` (node + web) → pass
- `npx vitest run` for all touched files: **283** renderer + **152** main-process passing; the touched ipc test suites (**343** tests) also pass.

No visible copy changed — entity escapes render identically to the original characters.