### PR TITLE
test(electron): de-flake context-graph date-axis tick test under load

### DIFF
--- a/apps/electron/src/components/context-graph/__tests__/layout.test.ts
+++ b/apps/electron/src/components/context-graph/__tests__/layout.test.ts
@@ -228,11 +228,14 @@ describe('date axis ticks (honest ordinal scale)', () => {
     expect(ticks[ticks.length - 1].dateMs).toBe(base + 59 * DAY)
   })
 
+  // Dynamically importing the canvas module can be starved past the default 5s
+  // timeout when the full suite runs in parallel; the import itself is <50ms in
+  // isolation. Give it headroom so heavy-load runs don't flake.
   it('tick labels render as short smart dates with the year', async () => {
     const { tickLabel } = await import('../StratifiedLensCanvas')
     expect(tickLabel(Date.parse('2026-06-01T12:00:00Z'))).toMatch(/Jun\s+1,\s+2026/)
     expect(tickLabel(Date.parse('2025-12-31T12:00:00Z'))).toMatch(/2025/)
-  })
+  }, 15000)
 })
 
 describe('dense-timeline binning (no sub-diameter slot spacing)', () => {


### PR DESCRIPTION
## What

Adds a 15s per-test timeout to `layout.test.ts > date axis ticks > 'tick labels render as short smart dates with the year'`.

## Why

The test does `await import('../StratifiedLensCanvas')`. Under full-suite parallelism that dynamic import can be starved past vitest's default 5000ms timeout and fail with `Test timed out in 5000ms` — even though the import is <50ms in isolation. Surfaced during the full `npx vitest run` for the Dependabot security triage (#74): 1 spurious failure out of 3515, which passes 23/23 in isolation.

This is the same load-flake class the repo has been hardening (e.g. #66, #68); the fix matches the repo's `{ timeout: 15000 }` convention for load-sensitive async work.

## Verification

- `npx vitest run src/components/context-graph/__tests__/layout.test.ts` → 23/23 pass with the change in place.
- No behavior change: only a timeout budget + explanatory comment were added; assertions and imports are untouched.