### PR TITLE
test(jensen-protocol): use the real H1E product id in device stand-ins

### DIFF
--- a/packages/jensen-protocol/tests/jensen-device.test.ts
+++ b/packages/jensen-protocol/tests/jensen-device.test.ts
@@ -749,7 +749,11 @@ describe('JensenDevice (transport-agnostic core)', () => {
         if (type === 'connect') connectHandler = h
       }) as unknown as USB['addEventListener'],
     })
-    const hidockDevice = { vendorId: 0x10d6, productId: USB_PRODUCT_IDS[0], productName: 'HiDock H1E' }
+    // USB_PRODUCT_IDS is a NAMED-KEY map (H1/H1E/P1/...), not an array — a positional
+    // `[0]` lookup yields undefined, which isHiDockUsbDevice() only tolerates because
+    // its productName check ("hidock") short-circuits first. Use the real H1E id here and
+    // in the other stand-ins below so they are faithful devices that detectModel() resolves.
+    const hidockDevice = { vendorId: 0x10d6, productId: USB_PRODUCT_IDS.H1E, productName: 'HiDock H1E' }
 
     // Gate closed → the connect event is ignored, tryConnect is not called.
     const devOff = new JensenDevice(usb)
@@ -777,7 +781,7 @@ describe('JensenDevice (transport-agnostic core)', () => {
   function makeTeardownDevice(reset: ReturnType<typeof vi.fn>, close: ReturnType<typeof vi.fn>): USBDevice {
     return {
       vendorId: 0x10d6,
-      productId: USB_PRODUCT_IDS[0],
+      productId: USB_PRODUCT_IDS.H1E,
       productName: 'HiDock H1E',
       opened: true,
       open: vi.fn(async () => {}),
@@ -852,7 +856,7 @@ describe('JensenDevice (transport-agnostic core)', () => {
     }
     return {
       vendorId: 0x10d6,
-      productId: USB_PRODUCT_IDS[0],
+      productId: USB_PRODUCT_IDS.H1E,
       productName: 'HiDock H1E',
       opened: true,
       open: vi.fn(async () => {}),
@@ -1042,7 +1046,7 @@ describe('JensenDevice (transport-agnostic core)', () => {
     const reset = vi.fn(async () => {})
     const fakeDevice = {
       vendorId: 0x10d6,
-      productId: USB_PRODUCT_IDS[0],
+      productId: USB_PRODUCT_IDS.H1E,
       productName: 'HiDock H1E',
       opened: true,
       open: vi.fn(async () => {}),


### PR DESCRIPTION
## Problem

`packages/jensen-protocol/tests/jensen-device.test.ts` built four fake USB devices with `productId: USB_PRODUCT_IDS[0]`.

`USB_PRODUCT_IDS` ([jensen-device.ts:107](https://github.com/sgeraldes/hidock-next/blob/beta/meeting-intelligence/packages/jensen-protocol/src/jensen-device.ts#L107)) is a **named-key map**, not an array:

```ts
export const USB_PRODUCT_IDS = { H1: 0xaf0c, H1E_OLD: 0xaf0d, H1E: 0xb00d, P1: 0xb00e, ... }
```

So `USB_PRODUCT_IDS[0]` evaluated to `undefined`.

## Why it stayed green

`isHiDockUsbDevice()` (jensen-device.ts:1069-1074) checks `productName` for `"hidock"` and returns early, **before** it ever looks at `productId`:

```ts
const name = device.productName?.toLowerCase() ?? ''
if (name.includes('hidock') || name.includes('jensen')) return true   // ← short-circuits here
return Object.values(USB_PRODUCT_IDS).includes(device.productId)      // ← never reached
```

Every mock sets `productName: 'HiDock H1E'`, so the productId branch was never exercised, and `detectModel(undefined)` fell through to `default → 'unknown'`.

The connect path logged the contradiction outright — verified locally by temporarily driving `tryConnect()` with each value:

| `productId` | detection log | resolved model |
|---|---|---|
| `undefined` (old `[0]`) | `[Jensen] tryConnect: detected HiDock H1E` | `[Jensen] Connected to unknown` ❌ |
| `0xb00d` (`.H1E`) | `[Jensen] tryConnect: detected HiDock H1E` | `[Jensen] Connected to hidock-h1e` ✅ |

## Fix

Replace all four with `USB_PRODUCT_IDS.H1E` (`0xb00d`) so each stand-in is a faithful H1E matching its own `productName`, and add a comment at the first site so the positional-lookup mistake doesn't return.

## Verification

- `npx vitest run tests/` — **61/61 passing**, 2 files (identical to the pre-change baseline, captured before editing)
- `npx tsc --noEmit` — clean
- No assertion changed behavior, as expected: none of the four tests assert on `getModel()`. The value is fidelity — the productId path is now real rather than silently bypassed.

## Notes

The same stale pattern was already fixed in `jensen-device-queueing-c5.test.ts`, which is on this branch's base — this brings the main device suite in line with that precedent. No production code touched; test-only change.

**No USB hardware was accessed** — all verification ran against injected mocks.
