### PR TITLE
fix(electron): calendar day keys use the local date, not UTC

### DIFF
--- a/apps/electron/src/lib/__tests__/calendar-utils.test.ts
+++ b/apps/electron/src/lib/__tests__/calendar-utils.test.ts
@@ -381,7 +381,13 @@ describe('groupByDay timezone independence', () => {
   const ORIGINAL_TZ = process.env.TZ
 
   afterEach(() => {
-    process.env.TZ = ORIGINAL_TZ
+    // Assigning undefined would coerce to the string "undefined" (an invalid TZ),
+    // leaking a polluted zone into later tests in this worker — delete instead.
+    if (ORIGINAL_TZ === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = ORIGINAL_TZ
+    }
   })
 
   it.each(['UTC', 'Asia/Tokyo', 'America/New_York'])('keys items by their local day in %s', (tz) => {

--- a/apps/electron/src/lib/__tests__/calendar-utils.test.ts
+++ b/apps/electron/src/lib/__tests__/calendar-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   computeVisibleHourRange,
   matchRecordingsToMeetings,
@@ -368,6 +368,39 @@ describe('groupByDay', () => {
 
     const key = '2026-03-02'
     expect(grouped[key]).toEqual([])
+  })
+})
+
+/**
+ * The day key must come from the LOCAL calendar date, matching the local-midnight
+ * view dates addDaysDSTSafe produces. A UTC-derived key (toISOString) silently
+ * shifts a day in every zone with a non-zero offset — and is invisible under the
+ * CI default of UTC, which is how it shipped. So pin the zone explicitly here.
+ */
+describe('groupByDay timezone independence', () => {
+  const ORIGINAL_TZ = process.env.TZ
+
+  afterEach(() => {
+    process.env.TZ = ORIGINAL_TZ
+  })
+
+  it.each(['UTC', 'Asia/Tokyo', 'America/New_York'])('keys items by their local day in %s', (tz) => {
+    process.env.TZ = tz
+
+    // Built after TZ is set, so these are local wall-clock times in that zone.
+    // Both edges of the day: a positive offset (JST) misfiles the early one, a
+    // negative offset (New York) misfiles the late one.
+    const items = [
+      { name: 'early', date: new Date(2026, 2, 2, 0, 30) },
+      { name: 'late', date: new Date(2026, 2, 2, 23, 30) },
+    ]
+    const viewDates = [new Date(2026, 2, 1), new Date(2026, 2, 2), new Date(2026, 2, 3)]
+
+    const grouped = groupByDay(items, (i) => i.date, viewDates)
+
+    expect(grouped['2026-03-02'].map((i) => i.name)).toEqual(['early', 'late'])
+    expect(grouped['2026-03-01']).toEqual([])
+    expect(grouped['2026-03-03']).toEqual([])
   })
 })
 

--- a/apps/electron/src/lib/calendar-utils.ts
+++ b/apps/electron/src/lib/calendar-utils.ts
@@ -569,6 +569,24 @@ export function formatDurationStr(seconds: number): string {
 }
 
 /**
+ * Day key (YYYY-MM-DD) for a Date, read in the LOCAL calendar — the same frame as
+ * the local-midnight dates addDaysDSTSafe produces and as getHours()/isToday()
+ * elsewhere in this module.
+ *
+ * Deliberately NOT `toISOString().split('T')[0]`: that reads the UTC calendar, so
+ * in any zone with a non-zero offset the key drifts a day away from the local date
+ * it is supposed to name. In JST that put every recording from 09:00 onward in the
+ * NEXT day's column and dropped the view's last day entirely — and it is invisible
+ * under a UTC CI, so keep the timezone-pinned test in calendar-utils.test.ts.
+ */
+export function toLocalDayKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
  * Group items by day key (YYYY-MM-DD)
  */
 export function groupByDay<T>(
@@ -579,12 +597,11 @@ export function groupByDay<T>(
   const grouped: Record<string, T[]> = {}
 
   for (const date of viewDates) {
-    const key = date.toISOString().split('T')[0]
-    grouped[key] = []
+    grouped[toLocalDayKey(date)] = []
   }
 
   for (const item of items) {
-    const key = getDate(item).toISOString().split('T')[0]
+    const key = toLocalDayKey(getDate(item))
     if (grouped[key]) {
       grouped[key].push(item)
     }

--- a/apps/electron/src/pages/Calendar.tsx
+++ b/apps/electron/src/pages/Calendar.tsx
@@ -59,6 +59,7 @@ import {
   buildCalendarRecordings,
   formatDurationStr,
   groupByDay,
+  toLocalDayKey,
   computeVisibleHourRange,
   recordingCategory,
   formatUnmatchedRecordingMeta,
@@ -1168,14 +1169,14 @@ export function Calendar() {
           <div className="flex-1 overflow-auto">
             <div className="grid grid-cols-7 h-full animate-rise-in" style={{ gridAutoRows: 'minmax(100px, 1fr)' }}>
               {monthDates.map((date) => {
-                const key = date.toISOString().split('T')[0]
+                const key = toLocalDayKey(date)
                 const dayMeetings = meetingsByMonth[key] || []
                 const today = isToday(date)
                 const isCurrentMonth = date.getMonth() === currentDate.getMonth()
                 const isWeekend = !isWorkDay(date)
                 // C-CAL-006: Count recordings for this day to show indicator badge
                 const dayRecordingCount = calendarRecordings.filter(r => {
-                  const rKey = r.startTime.toISOString().split('T')[0]
+                  const rKey = toLocalDayKey(r.startTime)
                   return rKey === key
                 }).length
 
@@ -1275,7 +1276,7 @@ export function Calendar() {
           <div className="flex border-b flex-shrink-0 overflow-y-scroll" style={{ scrollbarGutter: 'stable' }}>
             <div className="w-14 flex-shrink-0" />
             {viewDates.map((date) => {
-              const key = date.toISOString().split('T')[0]
+              const key = toLocalDayKey(date)
               const today = isToday(date)
               const isWeekend = !isWorkDay(date)
 
@@ -1327,7 +1328,7 @@ export function Calendar() {
 
               {/* Day Columns */}
               {viewDates.map((date) => {
-                const key = date.toISOString().split('T')[0]
+                const key = toLocalDayKey(date)
                 // dayMeetings variable reserved for future per-day rendering
                 const _dayMeetings = meetingsByDay[key] || []
                 void _dayMeetings


### PR DESCRIPTION
## Problem

`groupByDay` (calendar-utils) builds its day keys with `toISOString().split('T')[0]`, and `Calendar.tsx` derives the same dictionary keys with its own copies of that expression. `toISOString()` reads the **UTC** calendar, but every `Date` feeding these keys has **local**-calendar semantics: `viewDates` are local midnights produced by `addDaysDSTSafe`, and the module's `getHours()` / `isToday()` are local too.

In any timezone with a non-zero offset the key drifts by one day. In JST (UTC+9) the column for local day D gets the key D-1, so every recording/meeting from 09:00 local onward renders in the next day's column, and the view's last day has no bucket at all and disappears.

## Fix

- Add `toLocalDayKey()` returning the local calendar date (`YYYY-MM-DD` from local date parts)
- Use it in `groupByDay` **and** in the four key-derivation sites in `Calendar.tsx` — fixing only one side would just shift the mismatch to the other

## Why tests didn't catch it

The existing `groupByDay` tests pass under UTC (local == UTC there), which is presumably how this shipped. This PR adds tests that pin `process.env.TZ` to `UTC` / `Asia/Tokyo` / `America/New_York`, so a UTC CI also catches the regression.

## Verification

- calendar-utils suite passes in all three pinned zones
- Full renderer suite and `typecheck:web` pass under both JST and UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calendar event grouping to use local calendar dates.
  * Fixed events near day boundaries appearing on the wrong date across different time zones.
  * Updated calendar month, header, and day views for consistent local-date display.
  * Improved date handling so recordings and meetings appear on the correct local day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->