### PR TITLE
feat(notes-agent): add HiNotes cloud sync bridge and Markdown vault export

### DIFF
--- a/notes-agent/README.md
+++ b/notes-agent/README.md
@@ -1,0 +1,85 @@
+# Agente organizador de notas (HiNotes)
+
+Un subagente de Claude Code que organiza las transcripciones que **HiDock** guarda en
+`~/.hidock/audio_metadata.db`: las titula, etiqueta, extrae action items, enlaza notas
+relacionadas y las exporta a un vault Markdown (compatible con Obsidian).
+
+## Piezas
+
+- **`notes-agent/hinotes_sync.py`** — puente que baja tus notas de la nube **HiNotes**
+  (hinotes.hidock.com) a la base local, usando tu AccessToken. Úsalo si tus notas ya
+  viven en la app/web de HiNotes (no en un dispositivo por USB).
+- **`notes-agent/hidock_notes.py`** — CLI (solo stdlib) que lee/escribe la base de HiDock
+  de forma segura y exporta Markdown. Solo modifica campos `user_*`; nunca la transcripción
+  ni el análisis de IA originales.
+- **`.claude/agents/notes-organizer.md`** — definición del subagente que usa ese CLI.
+
+## Flujo A — notas ya en la nube HiNotes (lo más común)
+
+```bash
+# 1. Consigue tu AccessToken: en https://hinotes.hidock.com → DevTools (F12) →
+#    Network → click en "Notes" → Headers → copia el valor de "AccessToken" (64 chars).
+export HINOTES_TOKEN=<tu token de 64 chars>
+
+python3 notes-agent/hinotes_sync.py probe    # verifica el token
+python3 notes-agent/hinotes_sync.py fetch     # descarga a ~/.hidock/hinotes_raw/*.json
+python3 notes-agent/hinotes_sync.py import    # importa a la base local
+python3 notes-agent/hidock_notes.py stats     # confirma cuántas notas hay
+```
+
+Luego, desde Claude Code: **"organiza mis notas"**.
+
+### Todo-en-uno y sincronización automática
+
+```bash
+# Guarda tu token una vez (para el sync automático):
+printf '%s' "<tu token>" > ~/.hidock/hinotes_token && chmod 600 ~/.hidock/hinotes_token
+
+# Sincroniza todo de una (fetch → import → unificar tags → exportar vault):
+bash notes-agent/sync_all.sh
+```
+
+**Automático (macOS launchd):** `~/Library/LaunchAgents/com.hinotes.sync.plist`
+corre `sync_all.sh` **diario a las 21:00**.
+- Cambiar frecuencia: edita `StartCalendarInterval` en el plist y recarga con
+  `launchctl unload ... && launchctl load ...`.
+- Desactivar: `launchctl unload ~/Library/LaunchAgents/com.hinotes.sync.plist`.
+- ⚠️ El AccessToken **expira**. Cuando pase, el sync sale con código 2 (ver `~/.hidock/sync.log`)
+  y hay que pegar un token nuevo en `~/.hidock/hinotes_token`.
+
+### Otras piezas
+
+- `canon_tags.py` — unifica tags duplicados/sinónimos (`--dry-run` para previsualizar).
+- `_Dossiers/` en el vault — documentos consolidados generados por el agente
+  (ej. `Lealtad-Retencion.md`, `Mis-Tareas.md`).
+
+## Requisitos previos
+
+1. Instalar y usar HiDock (Desktop app) para descargar y **transcribir** grabaciones.
+   Eso crea `~/.hidock/audio_metadata.db`. Sin al menos una nota transcrita, no hay nada que organizar.
+2. Claude Code (para invocar el subagente).
+
+## Uso
+
+Desde Claude Code, pídele en lenguaje natural:
+
+- "organiza mis notas nuevas"
+- "¿qué grabé esta semana? sácame los action items"
+- "etiqueta las notas sin tags y expórtalas a Markdown"
+
+Claude delega en el subagente `notes-organizer`, que corre el CLI por debajo.
+
+## Uso manual del CLI (sin agente)
+
+```bash
+python3 notes-agent/hidock_notes.py stats
+python3 notes-agent/hidock_notes.py pending
+python3 notes-agent/hidock_notes.py show REC0001.hda
+python3 notes-agent/hidock_notes.py set REC0001.hda --title "1:1 con Ana" --tags "trabajo,1on1" --action-items "Enviar brief;Agendar seguimiento"
+python3 notes-agent/hidock_notes.py export --all
+```
+
+Variables de entorno:
+
+- `HIDOCK_DB` — ruta a la base (default `~/.hidock/audio_metadata.db`).
+- `HIDOCK_VAULT` — carpeta del vault Markdown (default `~/HiNotes-Vault`).

--- a/notes-agent/canon_tags.py
+++ b/notes-agent/canon_tags.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+canon_tags.py — Unifica tags duplicados/sinónimos en la base local de HiDock.
+
+Aplica un mapeo canónico (case-insensitive) sobre `user_tags`, deduplica dentro de
+cada nota y preserva el orden. Solo toca tags que estén en el mapeo; el resto se
+conserva tal cual (salvo colapsar duplicados por mayúsculas/espacios).
+
+Uso:
+    python3 canon_tags.py --dry-run   # muestra qué cambiaría, sin escribir
+    python3 canon_tags.py             # aplica los cambios
+"""
+import argparse
+import collections
+import json
+import os
+import sqlite3
+
+DB = os.environ.get("HIDOCK_DB", os.path.join(os.path.expanduser("~"), ".hidock", "audio_metadata.db"))
+
+# canónico -> lista de variantes (todo se compara en minúsculas/strip).
+CLUSTERS = {
+    "Lealtad y Retención": [
+        "programa de lealtad", "fidelización de clientes", "fidelización",
+        "retención de clientes", "retención", "lealtad", "programa de fidelización",
+        "retención de clientes", "customer retention", "loyalty program",
+    ],
+    "E-commerce": ["comercio electrónico", "ecommerce", "e-commerce", "e commerce"],
+    "Estrategia de Marketing": ["estrategias de marketing", "estrategia de marketing"],
+    "Análisis de Desempeño": [
+        "análisis de rendimiento", "análisis de desempeño", "métricas de desempeño",
+        "análisis de performance", "revisión de desempeño", "reunión de desempeño",
+    ],
+    "Campañas de Marketing": [
+        "campañas publicitarias", "campaña publicitaria", "campañas promocionales",
+        "campaña promocional", "campaña de marketing", "campañas de marketing",
+        "campañas", "campaña",
+    ],
+    "Paid Media": ["medios pagados", "paid media", "publicidad pagada"],
+    "Automatización": ["automatización de procesos", "automatización"],
+    "Producción de Video": ["producción de videos", "producción de video"],
+    "Análisis de Datos": ["análisis de datos", "analítica de datos", "gestión de datos", "integración de datos"],
+    "Segmentación de Clientes": ["segmentación de audiencia", "segmentación de clientes", "segmentación"],
+    "SEO": ["seo", "optimización seo", "posicionamiento seo"],
+    "Reunión de Marketing": ["reunión de marketing", "reuniones de marketing"],
+    "Reunión de Equipo": ["reunión de equipo", "reuniones de equipo", "reuniones de equipo"],
+    "Presupuesto": ["planificación presupuestaria", "gestión de presupuesto", "presupuesto",
+                    "reunión presupuestaria", "gestión de presupuesto"],
+    "Experiencia del Cliente": ["experiencia del cliente", "experiencia de cliente"],
+    "Análisis de Ventas": ["análisis de ventas", "estrategia de ventas", "estrategia comercial"],
+}
+
+# Construye índice variante(lower) -> canónico
+VARIANT_TO_CANON = {}
+for canon, variants in CLUSTERS.items():
+    VARIANT_TO_CANON[canon.lower()] = canon
+    for v in variants:
+        VARIANT_TO_CANON[v.strip().lower()] = canon
+
+
+def canonize(tags):
+    seen, out = set(), []
+    for t in tags:
+        key = str(t).strip().lower()
+        canon = VARIANT_TO_CANON.get(key, str(t).strip())
+        if canon.lower() not in seen:
+            seen.add(canon.lower())
+            out.append(canon)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(DB)
+    rows = conn.execute("SELECT filename, user_tags FROM audio_metadata").fetchall()
+
+    before = collections.Counter()
+    after = collections.Counter()
+    changed = 0
+    updates = []
+    for fn, raw in rows:
+        tags = json.loads(raw or "[]")
+        before.update(tags)
+        new = canonize(tags)
+        after.update(new)
+        if new != tags:
+            changed += 1
+            updates.append((json.dumps(new, ensure_ascii=False), fn))
+
+    print(f"Tags únicos antes: {len(before)}  →  después: {len(after)}")
+    print(f"Notas afectadas: {changed}")
+    print("\nTop tags después de unificar:")
+    for tag, n in after.most_common(15):
+        print(f"  {n:3}  {tag}")
+
+    if args.dry_run:
+        print("\n(dry-run: no se escribió nada)")
+        return
+
+    for new_tags, fn in updates:
+        conn.execute("UPDATE audio_metadata SET user_tags=?, updated_at=CURRENT_TIMESTAMP WHERE filename=?",
+                     (new_tags, fn))
+    conn.commit()
+    print(f"\n✅ Aplicado a {changed} notas.")
+
+
+if __name__ == "__main__":
+    main()

--- a/notes-agent/hidock_notes.py
+++ b/notes-agent/hidock_notes.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+hidock_notes.py — Herramienta CLI para el agente organizador de notas de HiDock.
+
+Da acceso determinista y seguro (solo stdlib) a la base de datos de HiDock
+(`~/.hidock/audio_metadata.db`) y exporta notas a un vault Markdown.
+
+El agente (LLM) decide QUÉ escribir (títulos, tags, resúmenes, action items);
+este script hace CÓMO leer/escribir de forma fiable, sin que el agente redacte
+SQL a mano. Todas las escrituras tocan solo los campos `user_*` y `display_title`
+— nunca la transcripción original ni el análisis de IA de HiDock.
+
+Uso:
+    python hidock_notes.py stats
+    python hidock_notes.py list [--status STATUS] [--untagged] [--limit N]
+    python hidock_notes.py show <filename>
+    python hidock_notes.py search "texto"
+    python hidock_notes.py pending            # notas que faltan por organizar
+    python hidock_notes.py set <filename> [--title T] [--tags a,b,c]
+                                 [--notes N] [--description D]
+                                 [--action-items "item1;item2"]
+    python hidock_notes.py export <filename|--all> [--out DIR]
+
+Salida en JSON para que el agente la parsee de forma fiable.
+"""
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+DEFAULT_DB = os.path.join(os.path.expanduser("~"), ".hidock", "audio_metadata.db")
+DEFAULT_VAULT = os.path.join(os.path.expanduser("~"), "HiNotes-Vault")
+
+# Campos que el agente puede modificar. La transcripción y el análisis de IA
+# de HiDock quedan intactos.
+JSON_FIELDS = {"ai_participants", "ai_action_items", "ai_topics", "ai_key_quotes",
+               "user_participants", "user_action_items", "user_tags"}
+
+
+def db_path():
+    return os.environ.get("HIDOCK_DB", DEFAULT_DB)
+
+
+def connect():
+    path = db_path()
+    if not os.path.exists(path):
+        die(f"No existe la base de HiDock en {path}. "
+            f"Abre la app de HiDock, descarga y procesa (transcribe) al menos "
+            f"una grabación primero, o define HIDOCK_DB si está en otra ruta.")
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def die(msg, code=1):
+    print(json.dumps({"error": msg}, ensure_ascii=False, indent=2))
+    sys.exit(code)
+
+
+def out(obj):
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def parse_json_field(value):
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+def row_to_dict(row, full=False):
+    d = dict(row)
+    for f in JSON_FIELDS:
+        if f in d:
+            d[f] = parse_json_field(d[f])
+    if not full:
+        # Vista compacta para listados: sin transcripción completa.
+        text = d.get("transcription_text") or ""
+        d["transcription_preview"] = (text[:280] + "…") if len(text) > 280 else text
+        d.pop("transcription_text", None)
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# Comandos de lectura
+# --------------------------------------------------------------------------- #
+def cmd_stats(args):
+    conn = connect()
+    cur = conn.cursor()
+    total = cur.execute("SELECT COUNT(*) FROM audio_metadata").fetchone()[0]
+    by_status = {r[0]: r[1] for r in cur.execute(
+        "SELECT processing_status, COUNT(*) FROM audio_metadata GROUP BY processing_status")}
+    transcribed = cur.execute(
+        "SELECT COUNT(*) FROM audio_metadata "
+        "WHERE transcription_text IS NOT NULL AND transcription_text != ''").fetchone()[0]
+    untagged = cur.execute(
+        "SELECT COUNT(*) FROM audio_metadata "
+        "WHERE (user_tags IS NULL OR user_tags = '' OR user_tags = '[]') "
+        "AND transcription_text IS NOT NULL AND transcription_text != ''").fetchone()[0]
+    untitled = cur.execute(
+        "SELECT COUNT(*) FROM audio_metadata "
+        "WHERE (user_title IS NULL OR user_title = '') "
+        "AND transcription_text IS NOT NULL AND transcription_text != ''").fetchone()[0]
+    out({
+        "db_path": db_path(),
+        "total_notes": total,
+        "transcribed": transcribed,
+        "by_status": by_status,
+        "needs_organizing": {"untagged": untagged, "untitled": untitled},
+    })
+
+
+def cmd_list(args):
+    conn = connect()
+    q = ("SELECT filename, date_created, duration_seconds, processing_status, "
+         "user_title, display_title, user_tags, ai_summary "
+         "FROM audio_metadata")
+    where, params = [], []
+    if args.status:
+        where.append("processing_status = ?")
+        params.append(args.status)
+    if args.untagged:
+        where.append("(user_tags IS NULL OR user_tags = '' OR user_tags = '[]')")
+        where.append("transcription_text IS NOT NULL AND transcription_text != ''")
+    if where:
+        q += " WHERE " + " AND ".join(where)
+    q += " ORDER BY date_created DESC"
+    if args.limit:
+        q += f" LIMIT {int(args.limit)}"
+    rows = [row_to_dict(r) for r in conn.execute(q, params)]
+    out({"count": len(rows), "notes": rows})
+
+
+def cmd_show(args):
+    conn = connect()
+    row = conn.execute("SELECT * FROM audio_metadata WHERE filename = ?",
+                       (args.filename,)).fetchone()
+    if not row:
+        die(f"No se encontró la nota '{args.filename}'.")
+    out(row_to_dict(row, full=True))
+
+
+def cmd_search(args):
+    conn = connect()
+    like = f"%{args.query}%"
+    rows = [row_to_dict(r) for r in conn.execute(
+        "SELECT filename, date_created, user_title, display_title, user_tags, ai_summary, "
+        "transcription_text FROM audio_metadata "
+        "WHERE transcription_text LIKE ? OR ai_summary LIKE ? OR user_title LIKE ? "
+        "OR user_notes LIKE ? OR user_tags LIKE ? "
+        "ORDER BY date_created DESC",
+        (like, like, like, like, like))]
+    out({"query": args.query, "count": len(rows), "notes": rows})
+
+
+def cmd_pending(args):
+    """Notas transcritas pero sin organizar (sin título o sin tags)."""
+    conn = connect()
+    rows = [row_to_dict(r) for r in conn.execute(
+        "SELECT filename, date_created, duration_seconds, ai_summary, "
+        "transcription_text, user_title, user_tags FROM audio_metadata "
+        "WHERE transcription_text IS NOT NULL AND transcription_text != '' "
+        "AND ((user_title IS NULL OR user_title = '') "
+        "     OR (user_tags IS NULL OR user_tags = '' OR user_tags = '[]')) "
+        "ORDER BY date_created DESC")]
+    out({"count": len(rows), "notes": rows})
+
+
+# --------------------------------------------------------------------------- #
+# Comando de escritura (solo campos user_* + display_title)
+# --------------------------------------------------------------------------- #
+def cmd_set(args):
+    conn = connect()
+    row = conn.execute("SELECT * FROM audio_metadata WHERE filename = ?",
+                       (args.filename,)).fetchone()
+    if not row:
+        die(f"No se encontró la nota '{args.filename}'.")
+
+    updates, params = [], []
+
+    if args.title is not None:
+        updates.append("user_title = ?")
+        params.append(args.title)
+    if args.description is not None:
+        updates.append("user_description = ?")
+        params.append(args.description)
+    if args.notes is not None:
+        updates.append("user_notes = ?")
+        params.append(args.notes)
+    if args.tags is not None:
+        tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+        updates.append("user_tags = ?")
+        params.append(json.dumps(tags, ensure_ascii=False))
+    if args.action_items is not None:
+        items = [i.strip() for i in args.action_items.split(";") if i.strip()]
+        updates.append("user_action_items = ?")
+        params.append(json.dumps(items, ensure_ascii=False))
+
+    if not updates:
+        die("Nada que actualizar: pasa al menos --title/--tags/--notes/etc.")
+
+    # Recalcular display_title (user_title > ai_summary > filename).
+    new_title = args.title if args.title is not None else row["user_title"]
+    display = new_title or row["ai_summary"] or row["filename"]
+    updates.append("display_title = ?")
+    params.append(display)
+    updates.append("updated_at = ?")
+    params.append(datetime.now(timezone.utc).isoformat())
+
+    params.append(args.filename)
+    conn.execute(f"UPDATE audio_metadata SET {', '.join(updates)} WHERE filename = ?",
+                 params)
+    conn.commit()
+    updated = conn.execute("SELECT * FROM audio_metadata WHERE filename = ?",
+                           (args.filename,)).fetchone()
+    out({"updated": args.filename, "note": row_to_dict(updated, full=True)})
+
+
+# --------------------------------------------------------------------------- #
+# Exportación a vault Markdown
+# --------------------------------------------------------------------------- #
+def slugify(text):
+    text = (text or "nota").strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    text = re.sub(r"[\s_-]+", "-", text).strip("-")
+    return text[:60] or "nota"
+
+
+def yaml_list(items):
+    if not items:
+        return "[]"
+    return "\n" + "\n".join(f"  - {json.dumps(str(i), ensure_ascii=False)}" for i in items)
+
+
+def note_to_markdown(d):
+    tags = d.get("user_tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    participants = d.get("user_participants") or d.get("ai_participants") or []
+    action_items = d.get("user_action_items") or d.get("ai_action_items") or []
+    topics = d.get("ai_topics") or []
+    title = d.get("user_title") or d.get("display_title") or d.get("ai_summary") or d.get("filename")
+    date = d.get("date_created") or ""
+    dur = d.get("duration_seconds")
+
+    fm = ["---",
+          f"title: {json.dumps(str(title), ensure_ascii=False)}",
+          f"aliases:{yaml_list([str(title)])}",
+          f"source_file: {json.dumps(d.get('filename'), ensure_ascii=False)}",
+          f"date: {json.dumps(str(date), ensure_ascii=False)}",
+          f"duration_seconds: {dur if dur is not None else 'null'}",
+          f"tags:{yaml_list(tags)}",
+          f"participants:{yaml_list(participants)}",
+          f"topics:{yaml_list(topics)}",
+          "---", ""]
+
+    transcript = d.get("transcription_text") or ""
+    # Contenido "rico" (notas estructuradas de HiNotes) trae sus propios encabezados
+    # y su propio resumen — en ese caso no repetimos un "## Resumen" aparte.
+    is_rich = "\n#" in transcript or transcript.strip().startswith("#")
+
+    body = [f"# {title}", ""]
+    summary = d.get("user_description") or d.get("ai_summary")
+    if summary and not is_rich:
+        body += ["## Resumen", "", summary, ""]
+    elif summary and is_rich:
+        # Resumen conciso como callout breve, sin duplicar el detallado interno.
+        body += ["> [!summary] En breve", f"> {summary}", ""]
+    if action_items:
+        body += ["## Action items", ""]
+        body += [f"- [ ] {i}" for i in action_items]
+        body += [""]
+    if d.get("user_notes"):
+        body += ["## Notas", "", d["user_notes"], ""]
+    key_quotes = d.get("ai_key_quotes") or []
+    if key_quotes:
+        body += ["## Citas clave", ""]
+        body += [f"> {q}" for q in key_quotes]
+        body += [""]
+    if transcript:
+        heading = "## Contenido" if is_rich else "## Transcripción"
+        body += [heading, "", transcript, ""]
+
+    return "\n".join(fm + body)
+
+
+def export_one(row, vault):
+    d = row_to_dict(row, full=True)
+    date = str(d.get("date_created") or "")[:10] or "sin-fecha"
+    folder = os.path.join(vault, date[:7] or "sin-fecha")  # YYYY-MM
+    os.makedirs(folder, exist_ok=True)
+    title = d.get("user_title") or d.get("display_title") or d.get("filename")
+    fname = f"{date}-{slugify(title)}.md"
+    path = os.path.join(folder, fname)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(note_to_markdown(d))
+    return path
+
+
+def cmd_export(args):
+    conn = connect()
+    vault = args.out or os.environ.get("HIDOCK_VAULT", DEFAULT_VAULT)
+    if args.all:
+        rows = conn.execute(
+            "SELECT * FROM audio_metadata "
+            "WHERE transcription_text IS NOT NULL AND transcription_text != '' "
+            "ORDER BY date_created DESC").fetchall()
+    else:
+        if not args.filename:
+            die("Pasa un <filename> o --all.")
+        rows = conn.execute("SELECT * FROM audio_metadata WHERE filename = ?",
+                            (args.filename,)).fetchall()
+        if not rows:
+            die(f"No se encontró la nota '{args.filename}'.")
+    paths = [export_one(r, vault) for r in rows]
+    out({"vault": vault, "exported": len(paths), "files": paths})
+
+
+# --------------------------------------------------------------------------- #
+def build_parser():
+    p = argparse.ArgumentParser(description="Herramienta CLI del agente de notas HiDock.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("stats", help="Resumen de la base y qué falta organizar.")
+
+    lp = sub.add_parser("list", help="Lista notas (vista compacta).")
+    lp.add_argument("--status")
+    lp.add_argument("--untagged", action="store_true")
+    lp.add_argument("--limit", type=int)
+
+    sp = sub.add_parser("show", help="Muestra una nota completa.")
+    sp.add_argument("filename")
+
+    se = sub.add_parser("search", help="Busca en transcripción, resumen, tags, notas.")
+    se.add_argument("query")
+
+    sub.add_parser("pending", help="Notas transcritas pero sin organizar.")
+
+    st = sub.add_parser("set", help="Actualiza campos de usuario de una nota.")
+    st.add_argument("filename")
+    st.add_argument("--title")
+    st.add_argument("--description")
+    st.add_argument("--notes")
+    st.add_argument("--tags", help="Lista separada por comas: trabajo,reunion,q3")
+    st.add_argument("--action-items", dest="action_items",
+                    help="Lista separada por punto y coma: 'enviar informe;llamar a Ana'")
+
+    ex = sub.add_parser("export", help="Exporta nota(s) al vault Markdown.")
+    ex.add_argument("filename", nargs="?")
+    ex.add_argument("--all", action="store_true")
+    ex.add_argument("--out", help="Directorio del vault (default ~/HiNotes-Vault).")
+
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    handlers = {
+        "stats": cmd_stats, "list": cmd_list, "show": cmd_show,
+        "search": cmd_search, "pending": cmd_pending, "set": cmd_set,
+        "export": cmd_export,
+    }
+    handlers[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/notes-agent/hinotes_sync.py
+++ b/notes-agent/hinotes_sync.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+hinotes_sync.py — Puente entre la nube HiNotes (hinotes.hidock.com) y lo local.
+
+Descarga las notas y carpetas de tu cuenta de HiNotes usando tu AccessToken y:
+  - las guarda como JSON crudo (para inspección / backup completo),
+  - las importa a la base local de HiDock (`~/.hidock/audio_metadata.db`),
+    de modo que el agente `notes-organizer` pueda trabajarlas y exportarlas a Markdown.
+
+Solo stdlib (urllib) — no requiere instalar nada.
+
+Cómo obtener tu AccessToken (una sola vez):
+  1. Entra a https://hinotes.hidock.com e inicia sesión.
+  2. Abre DevTools (F12 o Cmd+Opt+I) → pestaña "Network".
+  3. Haz clic en "Notes" para que se dispare una petición.
+  4. Clic en cualquier request → pestaña "Headers" → busca el header "AccessToken".
+  5. Copia el valor de 64 caracteres.
+
+Uso:
+  export HINOTES_TOKEN=<tu token de 64 chars>
+  python3 hinotes_sync.py probe          # verifica token + muestra tu info
+  python3 hinotes_sync.py fetch          # descarga notas+carpetas a JSON crudo
+  python3 hinotes_sync.py import         # importa el JSON descargado a la base local
+  python3 hinotes_sync.py fetch --import # todo de una
+"""
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import urllib.request
+import urllib.error
+import urllib.parse
+from datetime import datetime, timezone
+
+BASE_URL = "https://hinotes.hidock.com"
+DEFAULT_DB = os.path.join(os.path.expanduser("~"), ".hidock", "audio_metadata.db")
+RAW_DIR = os.path.join(os.path.expanduser("~"), ".hidock", "hinotes_raw")
+
+
+def token():
+    t = os.environ.get("HINOTES_TOKEN", "").strip()
+    if not t:
+        die("Falta el AccessToken. Ponlo con:  export HINOTES_TOKEN=<token de 64 chars>\n"
+            "Cómo obtenerlo: DevTools (F12) → Network → click en Notes → Headers → 'AccessToken'.")
+    if len(t) != 64 or not t.isalnum():
+        die(f"El token no tiene el formato esperado (64 chars alfanuméricos); recibí {len(t)} chars.")
+    return t
+
+
+def die(msg, code=1):
+    print(json.dumps({"error": msg}, ensure_ascii=False, indent=2))
+    sys.exit(code)
+
+
+def out(obj):
+    print(json.dumps(obj, ensure_ascii=False, indent=2, default=str))
+
+
+def api(endpoint, method="POST", body=None, content_type="application/x-www-form-urlencoded"):
+    """Llama al API de HiNotes. Devuelve el campo `data` en éxito, o lanza."""
+    url = f"{BASE_URL}{endpoint}"
+    data = b""
+    headers = {"AccessToken": token(), "Content-Type": content_type,
+               "Accept": "application/json"}
+    if body is not None:
+        if content_type == "application/json":
+            data = json.dumps(body).encode("utf-8")
+        else:
+            data = urllib.parse.urlencode(body).encode("utf-8") if body else b""
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            die("401: token inválido o expirado. Vuelve a copiar el AccessToken desde DevTools.")
+        die(f"HTTP {e.code} en {endpoint}: {e.read().decode('utf-8', 'replace')[:300]}")
+    except urllib.error.URLError as e:
+        die(f"Error de red llamando {endpoint}: {e.reason}")
+    if payload.get("error") not in (0, None):
+        die(f"API HiNotes error en {endpoint}: {payload.get('message')} (raw: {json.dumps(payload)[:300]})")
+    return payload.get("data")
+
+
+# --------------------------------------------------------------------------- #
+def cmd_probe(args):
+    info = api("/v1/user/info")
+    out({"ok": True, "user": info})
+
+
+NOTES_DIR = os.path.join(RAW_DIR, "notes")  # cache de note/info por nota (resumible)
+
+
+def _sleep(seconds):
+    # time.sleep no está bloqueado en scripts normales; solo lo evitamos en workflows.
+    import time
+    time.sleep(seconds)
+
+
+def cmd_fetch(args):
+    os.makedirs(RAW_DIR, exist_ok=True)
+    os.makedirs(NOTES_DIR, exist_ok=True)
+
+    # 1) Carpetas (para mapear folderId -> nombre).
+    folders = api("/v1/folder/list") or []
+    with open(os.path.join(RAW_DIR, "folders.json"), "w", encoding="utf-8") as f:
+        json.dump(folders, f, ensure_ascii=False, indent=2)
+
+    # 2) Listado paginado de todas las notas (metadata + conciseSummary).
+    stubs, page, total_pages = [], 0, 1
+    while page < total_pages:
+        data = api("/v2/note/list", body={"pageIndex": page, "size": 10}) or {}
+        stubs.extend(data.get("content", []))
+        total_pages = data.get("totalPages", 1)
+        page += 1
+        if page % 5 == 0:
+            print(f"  …listando: {len(stubs)}/{data.get('totalElements','?')} notas",
+                  file=sys.stderr)
+        _sleep(0.15)
+    with open(os.path.join(RAW_DIR, "notes.json"), "w", encoding="utf-8") as f:
+        json.dump(stubs, f, ensure_ascii=False, indent=2)
+
+    # 3) Contenido completo por nota vía note/info (resumible: cachea cada una).
+    fetched_full, cached = 0, 0
+    if not args.list_only:
+        for i, s in enumerate(stubs):
+            nid = str(s.get("id"))
+            dest = os.path.join(NOTES_DIR, f"{nid}.json")
+            if os.path.exists(dest) and not args.refresh:
+                cached += 1
+                continue
+            info = api("/v2/note/info", body={"id": nid})
+            with open(dest, "w", encoding="utf-8") as f:
+                json.dump(info, f, ensure_ascii=False, indent=2)
+            fetched_full += 1
+            if fetched_full % 25 == 0:
+                print(f"  …contenido: {i + 1}/{len(stubs)}", file=sys.stderr)
+            _sleep(0.15)
+
+    out({"folders": len(folders), "notes_listed": len(stubs),
+         "content_downloaded": fetched_full, "content_cached": cached,
+         "raw_dir": RAW_DIR,
+         "next": "python3 hinotes_sync.py import"})
+    if args.do_import:
+        _import()
+
+
+def _folder_map():
+    path = os.path.join(RAW_DIR, "folders.json")
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        folders = json.load(f)
+    return {str(fo.get("id")): fo.get("name") for fo in folders if isinstance(fo, dict)}
+
+
+def _epoch_ms_to_iso(v):
+    try:
+        ms = int(v)
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def cmd_import(args):
+    _import()
+
+
+def _import():
+    notes_path = os.path.join(RAW_DIR, "notes.json")
+    if not os.path.exists(notes_path):
+        die("No hay notes.json. Corre primero: python3 hinotes_sync.py fetch")
+    with open(notes_path, encoding="utf-8") as f:
+        stubs = json.load(f)
+    if not stubs:
+        die("notes.json está vacío.")
+
+    fmap = _folder_map()
+    db = os.environ.get("HIDOCK_DB", DEFAULT_DB)
+    os.makedirs(os.path.dirname(db), exist_ok=True)
+    conn = sqlite3.connect(db)
+    _ensure_schema(conn)
+
+    imported, skipped, no_content = 0, 0, 0
+    now = datetime.now(timezone.utc).isoformat()
+    for s in stubs:
+        nid = str(s.get("id"))
+        # Contenido completo desde el cache de note/info (si se descargó).
+        full = {}
+        cache = os.path.join(NOTES_DIR, f"{nid}.json")
+        if os.path.exists(cache):
+            with open(cache, encoding="utf-8") as f:
+                full = json.load(f) or {}
+
+        title = full.get("title") or s.get("title") or f"Nota {nid}"
+        # markdown es el contenido rico (transcripción + notas estructuradas).
+        content = full.get("markdown") or full.get("html") or ""
+        if not content:
+            no_content += 1
+        summary = full.get("conciseSummary") or s.get("conciseSummary") or full.get("summary")
+        created = _epoch_ms_to_iso(s.get("createTime") or full.get("createTime"))
+        dur_ms = s.get("duration") or full.get("duration") or 0
+        try:
+            duration = float(dur_ms) / 1000.0  # la API entrega ms
+        except (TypeError, ValueError):
+            duration = 0.0
+        lang = s.get("language") or full.get("language")
+
+        # Tags: nombre de carpeta + tags propios de la nota.
+        tags = []
+        folder_name = fmap.get(str(s.get("folderId") or full.get("folderId")))
+        if folder_name:
+            tags.append(folder_name)
+        raw_tags = full.get("tags") or s.get("tags")
+        if isinstance(raw_tags, list):
+            tags += [t.get("name") if isinstance(t, dict) else str(t) for t in raw_tags]
+        elif isinstance(raw_tags, str) and raw_tags.strip():
+            tags += [t.strip() for t in raw_tags.split(",") if t.strip()]
+
+        filename = f"hinote-{nid}"
+        try:
+            conn.execute("""
+                INSERT INTO audio_metadata
+                    (filename, file_path, file_size, duration_seconds, date_created,
+                     processing_status, transcription_text, transcription_language,
+                     ai_summary, user_title, user_tags, display_title, updated_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(filename) DO UPDATE SET
+                    transcription_text=excluded.transcription_text,
+                    ai_summary=excluded.ai_summary,
+                    date_created=excluded.date_created,
+                    duration_seconds=excluded.duration_seconds,
+                    display_title=excluded.display_title,
+                    updated_at=excluded.updated_at
+            """, (
+                filename, f"hinotes://{nid}", 0, duration, created,
+                "completed", content, lang, summary or "",
+                title, json.dumps(tags, ensure_ascii=False),
+                title or summary or filename, now,
+            ))
+            imported += 1
+        except sqlite3.Error as e:
+            skipped += 1
+            print(f"  ⚠️  {filename}: {e}", file=sys.stderr)
+    conn.commit()
+    out({"imported": imported, "skipped": skipped,
+         "sin_contenido_completo": no_content, "db": db,
+         "next": "python3 hidock_notes.py stats  →  luego 'organiza mis notas' en Claude Code."})
+
+
+def _ensure_schema(conn):
+    """Crea el esquema de HiDock si la base aún no existe (mismo esquema que la app)."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS audio_metadata (
+            filename TEXT PRIMARY KEY, file_path TEXT NOT NULL, file_size INTEGER NOT NULL,
+            duration_seconds REAL NOT NULL, date_created TIMESTAMP NOT NULL,
+            processing_status TEXT NOT NULL DEFAULT 'not_processed',
+            processing_started_at TIMESTAMP, processing_completed_at TIMESTAMP, processing_error TEXT,
+            transcription_text TEXT, transcription_confidence REAL, transcription_language TEXT,
+            ai_summary TEXT, ai_participants TEXT, ai_action_items TEXT, ai_topics TEXT,
+            ai_sentiment TEXT, ai_key_quotes TEXT,
+            user_title TEXT, user_description TEXT, user_participants TEXT, user_action_items TEXT,
+            user_tags TEXT, user_notes TEXT, display_title TEXT, display_description TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+    """)
+    conn.commit()
+
+
+def build_parser():
+    p = argparse.ArgumentParser(description="Sincroniza notas de HiNotes cloud a local.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("probe", help="Verifica el token y muestra tu info de usuario.")
+    fp = sub.add_parser("fetch", help="Descarga notas+carpetas+contenido a JSON crudo.")
+    fp.add_argument("--import", dest="do_import", action="store_true",
+                    help="Importa a la base local justo después de descargar.")
+    fp.add_argument("--list-only", dest="list_only", action="store_true",
+                    help="Solo metadata (sin bajar el contenido completo por nota).")
+    fp.add_argument("--refresh", action="store_true",
+                    help="Re-descarga el contenido aunque ya esté en cache.")
+    sub.add_parser("import", help="Importa el JSON descargado a la base local.")
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    {"probe": cmd_probe, "fetch": cmd_fetch, "import": cmd_import}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/notes-agent/sync_all.sh
+++ b/notes-agent/sync_all.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# sync_all.sh — Sincroniza HiNotes → local → vault Markdown, todo de una.
+# Pensado para correr a mano o desde un job programado (launchd/cron).
+#
+# El AccessToken se lee de ~/.hidock/hinotes_token (una sola línea).
+# Cuando el token expire, actualiza ESE archivo con uno nuevo (DevTools → AccessToken).
+
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+TOKEN_FILE="$HOME/.hidock/hinotes_token"
+LOG="$HOME/.hidock/sync.log"
+
+if [ ! -f "$TOKEN_FILE" ]; then
+  echo "❌ Falta $TOKEN_FILE con tu AccessToken de HiNotes." | tee -a "$LOG"
+  exit 1
+fi
+export HINOTES_TOKEN="$(tr -d '[:space:]' < "$TOKEN_FILE")"
+
+echo "===== sync $(date '+%Y-%m-%d %H:%M:%S') =====" >> "$LOG"
+
+# 1) Verifica el token; si expiró, avisa y sale sin romper nada.
+if ! python3 "$DIR/hinotes_sync.py" probe >/dev/null 2>>"$LOG"; then
+  echo "⚠️  Token inválido/expirado. Actualiza $TOKEN_FILE." | tee -a "$LOG"
+  exit 2
+fi
+
+# 2) Descarga (incremental: sólo baja el contenido de notas nuevas gracias al cache).
+python3 "$DIR/hinotes_sync.py" fetch   >> "$LOG" 2>&1
+# 3) Importa a la base local.
+python3 "$DIR/hinotes_sync.py" import  >> "$LOG" 2>&1
+# 4) Unifica tags.
+python3 "$DIR/canon_tags.py"           >> "$LOG" 2>&1
+# 5) Re-exporta el vault Markdown.
+python3 "$DIR/hidock_notes.py" export --all >> "$LOG" 2>&1
+
+echo "✅ sync ok $(date '+%H:%M:%S')" >> "$LOG"
+echo "Sincronización completa. Log: $LOG"


### PR DESCRIPTION
## Description

The desktop app reads recordings from a HiDock device over USB, but notes that live only in the **HiNotes cloud** (`hinotes.hidock.com`) had no path into the local database. This adds a small, stdlib-only bridge that closes that gap, plus a CLI for working with the local database and exporting to a Markdown vault.

Everything lives in a new top-level `notes-agent/` directory. No existing file is modified.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

None — opened directly.

## Changes Made

- **`hinotes_sync.py`** — fetches folders, note list and per-note content from the HiNotes API into raw JSON (`~/.hidock/hinotes_raw/`), then imports into `~/.hidock/audio_metadata.db`. Per-note caching makes fetches resumable and incremental (`--refresh` to force, `--list-only` for metadata only). Creates the schema if the database does not exist yet, matching the app's own schema. Subcommands: `probe`, `fetch`, `import`.
- **`hidock_notes.py`** — read/write CLI over the local database with JSON output, so an automated caller never has to hand-write SQL. Writes touch **only** `user_*` fields and `display_title`; original transcripts and AI analysis are never modified. Exports notes to an Obsidian-style Markdown vault organized by `YYYY-MM`, with YAML frontmatter. Subcommands: `stats`, `list`, `show`, `search`, `pending`, `set`, `export`.
- **`canon_tags.py`** — collapses synonym and case-variant tags into canonical names, with `--dry-run`.
- **`sync_all.sh`** — chains fetch → import → canonicalize tags → export, suitable for cron/launchd.
- **`README.md`** — setup and both usage flows (cloud-first and device-first).

## Testing

Manual testing on macOS against a real HiNotes account: full `fetch` of ~420 notes, `import`, tag canonicalization and vault export all round-trip correctly. Resumability verified by interrupting a fetch and re-running it — cached notes are skipped.

### Desktop Application

- [x] Manual testing completed
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

### Device Testing

- [x] Not applicable — this path does not touch USB or the device at all

No automated tests are included; happy to add them if you'd like, though it would mean introducing a mocking layer for the HiNotes HTTP API.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (unaffected — no existing file is touched)

## Breaking Changes

None. Nothing outside `notes-agent/` is modified, and the tools are opt-in.

## Additional Notes

Three things worth your attention as reviewer:

1. **Credentials.** The access token is read from `$HINOTES_TOKEN` or `~/.hidock/hinotes_token` and is never written to the repo. The README documents obtaining it via DevTools, since HiNotes exposes no official API key flow that I could find. If you would rather not document that in-tree, say so and I'll trim it.

2. **`canon_tags.py` ships my own tag taxonomy.** The `CLUSTERS` dictionary is currently hardcoded with Spanish marketing tags from my use case. It should probably move to an external config file — happy to do that in this PR if you prefer it before merge.

3. **Unofficial API surface.** `hinotes_sync.py` targets `hinotes.hidock.com` endpoints (`/v1/user/info`, `/v1/folder/list`, `/v2/note/list`, `/v2/note/info`) observed from the web client, not a published API. It may break if HiNotes changes them. Calls are rate-limited with a small sleep and are read-only — nothing is ever written back to the cloud.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to synchronize HiNotes content, import it locally, and export notes to Markdown.
  - Added commands for viewing statistics, listing and searching notes, identifying pending items, and updating note fields.
  - Added tag cleanup with duplicate removal, canonical labels, reporting, and dry-run support.
  - Added automated daily synchronization with token validation, logging, and incremental updates.

- **Documentation**
  - Added Spanish documentation covering setup, usage, automation, exports, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->