### PR TITLE
fix: recognize HiDock H1 product ID 0xB00C in every device map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Device detection**: Added product ID `0xB00C` (45068) for the HiDock H1 to every device map (desktop, web, jensen-protocol, storage-controller). It is the primary H1 PID in the official HiNotes jensen.js; H1 units reporting it were not recognized. Corrected the `0xAF0C` comments, which claimed 45068 decimal (it is 44812).
 - **Database**: Fixed critical initialization crash on fresh installs by re-ordering `SCHEMA` to satisfy foreign key constraints.
 - **Database**: Automated V11 migration logic to correctly apply schema changes (`knowledge_captures`, `audio_sources`, etc.) and migration columns to existing databases.
 - **Database**: Added missing migration tracking columns (`migrated_to_capture_id`, `migration_status`, `migrated_at`) to the base `recordings` table definition.

--- a/apps/desktop/src/constants.py
+++ b/apps/desktop/src/constants.py
@@ -20,7 +20,8 @@ ALL_VENDOR_IDS = [DEFAULT_VENDOR_ID, ALTERNATE_VENDOR_ID]
 # Source: Official HiDock HiNotes jensen.js (December 2025)
 HIDOCK_PRODUCT_IDS = [
     # Original product IDs
-    0xAF0C,  # H1 (45068 decimal)
+    0xAF0C,  # H1 (44812 decimal, older PID)
+    0xB00C,  # H1 (45068 decimal, newer PID)
     0xAF0D,  # H1E (45069 decimal, older PID)
     0xB00D,  # H1E (newer PID)
     0xAF0E,  # P1 (45070 decimal, older PID)
@@ -38,6 +39,7 @@ HIDOCK_PRODUCT_IDS = [
 # Product ID to model name mapping
 PRODUCT_ID_MODEL_MAP = {
     0xAF0C: "hidock-h1",
+    0xB00C: "hidock-h1",
     0x0100: "hidock-h1",
     0x0102: "hidock-h1",
     0xAF0D: "hidock-h1e",

--- a/apps/desktop/src/device_interface.py
+++ b/apps/desktop/src/device_interface.py
@@ -670,6 +670,7 @@ def detect_device_model(vendor_id: int, product_id: int) -> DeviceModel:
     """
     model_map = {
         0xAF0C: DeviceModel.H1,
+        0xB00C: DeviceModel.H1,  # H1 (newer PID)
         0x0100: DeviceModel.H1,  # H1 alt
         0x0102: DeviceModel.H1,  # H1 alt
         0xAF0D: DeviceModel.H1E,

--- a/apps/desktop/src/enhanced_device_selector.py
+++ b/apps/desktop/src/enhanced_device_selector.py
@@ -296,6 +296,7 @@ class EnhancedDeviceSelector(ctk.CTkFrame):
         # HiDock device VID/PID combinations
         hidock_devices = [
             (0x10D6, 0xAF0C),  # H1
+            (0x10D6, 0xB00C),  # H1 (newer PID)
             (0x10D6, 0xAF0D),  # H1E variant
             (0x10D6, 0xAF0E),  # P1
             (0x10D6, 0xB00E),  # P1 variant
@@ -307,6 +308,7 @@ class EnhancedDeviceSelector(ctk.CTkFrame):
         """Get HiDock model name from product ID."""
         model_map = {
             0xAF0C: "H1",
+            0xB00C: "H1",
             0xAF0D: "Device",  # H1E variant
             0xAF0E: "P1",
             0xB00E: "P1 Variant",

--- a/apps/desktop/tests/test_constants.py
+++ b/apps/desktop/tests/test_constants.py
@@ -34,6 +34,13 @@ class TestConstants:
         # entry in the canonical product-ID list defined in constants.py.
         assert constants.DEFAULT_PRODUCT_ID == 0xAF0C
 
+    def test_h1_newer_product_id_recognized(self):
+        """H1 units report 0xB00C (45068) — the primary H1 PID in official jensen.js."""
+        assert 0xB00C in constants.HIDOCK_PRODUCT_IDS
+        assert constants.PRODUCT_ID_MODEL_MAP[0xB00C] == "hidock-h1"
+        # 0xAF0C is the older H1 PID (44812), still supported
+        assert constants.PRODUCT_ID_MODEL_MAP[0xAF0C] == "hidock-h1"
+
     def test_endpoint_constants(self):
         """Test endpoint address constants."""
         import constants

--- a/apps/web/src/constants/index.ts
+++ b/apps/web/src/constants/index.ts
@@ -19,7 +19,8 @@ export const HIDOCK_VENDOR_IDS = [
 // Source: Official HiDock HiNotes jensen.js (December 2025)
 export const HIDOCK_PRODUCT_IDS = {
   // H1 devices
-  H1: 0xAF0C,           // 45068 decimal
+  H1: 0xAF0C,           // 44812 decimal (older PID)
+  H1_NEW: 0xB00C,       // 45068 decimal (newer PID)
   H1_ALT_1: 0x0100,     // 256 decimal (alt)
   H1_ALT_2: 0x0102,     // 258 decimal (alt)
   // H1E devices
@@ -41,6 +42,7 @@ export const HIDOCK_PRODUCT_IDS = {
 // All Product IDs as an array for device filtering
 export const ALL_HIDOCK_PRODUCT_IDS = [
   HIDOCK_PRODUCT_IDS.H1,
+  HIDOCK_PRODUCT_IDS.H1_NEW,
   HIDOCK_PRODUCT_IDS.H1_ALT_1,
   HIDOCK_PRODUCT_IDS.H1_ALT_2,
   HIDOCK_PRODUCT_IDS.H1E,

--- a/apps/web/src/interfaces/deviceInterface.ts
+++ b/apps/web/src/interfaces/deviceInterface.ts
@@ -524,7 +524,8 @@ export class DeviceManager {
 export function detectDeviceModel(_vendorId: number, productId: number): DeviceModel {
     const modelMap: Record<number, DeviceModel> = {
         // H1 devices
-        0xAF0C: DeviceModel.H1,   // 45068 decimal
+        0xAF0C: DeviceModel.H1,   // 44812 decimal (older PID)
+        0xB00C: DeviceModel.H1,   // 45068 decimal (newer PID)
         0x0100: DeviceModel.H1,   // 256 decimal (alt)
         0x0102: DeviceModel.H1,   // 258 decimal (alt)
         // H1E devices

--- a/packages/jensen-protocol/src/jensen-device.ts
+++ b/packages/jensen-protocol/src/jensen-device.ts
@@ -106,6 +106,7 @@ export const USB_VENDOR_IDS: number[] = [0x10d6, 0x3887]
 
 export const USB_PRODUCT_IDS = {
   H1: 0xaf0c,
+  H1_NEW: 0xb00c,
   H1E_OLD: 0xaf0d,
   H1E: 0xb00d,
   P1_OLD: 0xaf0e,
@@ -1076,6 +1077,7 @@ export class JensenDevice {
   private detectModel(productId: number): DeviceModel {
     switch (productId) {
       case USB_PRODUCT_IDS.H1:
+      case USB_PRODUCT_IDS.H1_NEW:
       case USB_PRODUCT_IDS.H1_ALT1:
       case USB_PRODUCT_IDS.H1_ALT2:
         return 'hidock-h1'

--- a/packages/storage-controller/src/usb/constants.ts
+++ b/packages/storage-controller/src/usb/constants.ts
@@ -8,6 +8,7 @@ export const USB_VENDOR_IDS: number[] = [0x10d6, 0x3887]
 // Product IDs
 export const USB_PRODUCT_IDS = {
   H1: 0xaf0c,
+  H1_NEW: 0xb00c,
   H1E_OLD: 0xaf0d,
   H1E: 0xb00d,
   P1_OLD: 0xaf0e,
@@ -24,6 +25,7 @@ export const USB_PRODUCT_IDS = {
 // Product ID to model name mapping
 export const PRODUCT_ID_MODEL_MAP: Record<number, DeviceModel> = {
   0xaf0c: 'hidock-h1',
+  0xb00c: 'hidock-h1',
   0x0100: 'hidock-h1',
   0x0102: 'hidock-h1',
   0xaf0d: 'hidock-h1e',

--- a/packages/storage-controller/src/usb/pyusb-bridge.py
+++ b/packages/storage-controller/src/usb/pyusb-bridge.py
@@ -42,6 +42,7 @@ import usb.util  # noqa: E402
 USB_VENDOR_IDS = [0x10D6, 0x3887]
 PRODUCT_ID_MODEL = {
     0xAF0C: "H1",
+    0xB00C: "H1",
     0xAF0D: "H1E",
     0xB00D: "H1E",
     0xAF0E: "P1",


### PR DESCRIPTION
## Problem

HiDock H1 units report `idProduct` **45068 = 0xB00C**, but every device map in the repo only lists **0xAF0C** for the H1 — so these docks are never detected (desktop, web, `jensen-protocol`, `storage-controller`).

The root cause is visible in the existing comments: `0xAF0C  # H1 (45068 decimal)`. That decimal is wrong — 0xAF0C is 44812; **45068 is 0xB00C**. The repo's own `docs/hardware/JENSEN_PROTOCOL_DEVICE_IDS_2026.md` already identifies 0xB00C as the *primary* H1 PID in the official HiNotes `jensen.js` and lists "Missing Product ID 0xB00C: H1 devices with 0xB00C not recognized" as an open issue. This PR closes that item.

## Change

Adds `0xB00C → hidock-h1` alongside `0xAF0C` in every place a product ID is enumerated (purely additive; ordering and `DEFAULT_PRODUCT_ID` untouched):

- `apps/desktop/src/constants.py` — `HIDOCK_PRODUCT_IDS` + `PRODUCT_ID_MODEL_MAP`
- `apps/desktop/src/device_interface.py` — `detect_device_model`
- `apps/desktop/src/enhanced_device_selector.py` — VID/PID allow-list + model names
- `apps/web/src/constants/index.ts` — `HIDOCK_PRODUCT_IDS.H1_NEW` + `ALL_HIDOCK_PRODUCT_IDS` (WebUSB filter)
- `apps/web/src/interfaces/deviceInterface.ts` — `detectDeviceModel`
- `packages/jensen-protocol/src/jensen-device.ts` — `USB_PRODUCT_IDS.H1_NEW` + `detectModel` switch (without the switch case the device passed `isHiDockUsbDevice` but resolved to `'unknown'`)
- `packages/storage-controller/src/usb/constants.ts` + `pyusb-bridge.py`
- Corrected the "45068 decimal" comments to 44812 for 0xAF0C
- Regression test `test_h1_newer_product_id_recognized` in `apps/desktop/tests/test_constants.py`
- CHANGELOG entry under Unreleased → Fixed

Line endings preserved per file (the CRLF sources stay CRLF).

## Verification

Tested against a physical HiDock H1 on macOS (`idVendor 0x10D6`, `idProduct 0xB00C`, firmware **5.3.0**, build 328448) with a minimal pyusb Jensen client on interface 0 / endpoints 0x01–0x82:

- `CMD_GET_DEVICE_INFO` (1) → version + serial parsed
- `CMD_GET_CARD_INFO` (16) → 32 GB reported
- `CMD_GET_FILE_COUNT` (6) / `CMD_GET_FILE_LIST` (4) → 3 recordings, records parse with the documented `version:u8 | name_len:u24 | name | length:u32 | skip 6 | sig:16` layout
- `CMD_TRANSFER_FILE` (5) → three `.hda` files streamed at ~2.8 MB/s, byte counts match the listing; files are plain MP3 (16 kHz mono, 64 kb/s) and play

`apps/desktop/tests/test_constants.py`: 11 passed (including the new test).

One observation for maintainers, not changed here: on this firmware `CMD_GET_CARD_INFO` returned `used=29760, capacity=29792` MB with only ~47 MB of files on the device, so the first field may be *free* space (or a pre-allocated partition) rather than *used* on H1 5.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HiDock H1 devices with the newer product ID are now correctly detected across desktop, web, and connected-device services.
  * Support for the existing H1 product ID remains intact.
  * Corrected product ID reference values in device identification comments.

* **Tests**
  * Added coverage confirming both H1 product IDs are recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->